### PR TITLE
feat: support for cargo binstall

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,4 +29,3 @@ walkdir = "2.4.0"
 
 [package.metadata.binstall]
 pkg-url = "{ repo }/releases/download/v{ version }/{ name }-v{ version }-{ target }{ archive-suffix }"
-pkg-fmt = "tgz"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,8 @@
 [package]
 name = "markdown-oxide"
-version = "0.1.0"
+version = "0.0.21"
 edition = "2021"
+repository = "https://github.com/Feel-ix-343/markdown-oxide"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
@@ -25,3 +26,7 @@ shellexpand = "3.1.0"
 tokio = { version = "1.34.0", features = ["full"] }
 tower-lsp = { git = "https://github.com/Feel-ix-343/tower-lsp" }
 walkdir = "2.4.0"
+
+[package.metadata.binstall]
+pkg-url = "{ repo }/releases/download/v{ version }/{ name }-v{ version }-{ target }{ archive-suffix }"
+pkg-fmt = "tgz"

--- a/README.md
+++ b/README.md
@@ -22,6 +22,15 @@ Markdown Oxide's features are implemented in the form of a language server aimin
         ```
     
     </details>
+
+    - <details>
+         <summary>Cargo binstall (from hosted binary)</summary>
+    
+        ```bash
+        cargo binstall markdown-oxide
+        ```
+    
+    </details>
     
     - <details>
          <summary>AUR (from source)</summary>
@@ -145,6 +154,15 @@ Markdown Oxide is available as an extension titled `Markdown Oxide`. Similarly t
         ```
     
     </details>
+
+    - <details>
+         <summary>Cargo binstall (from hosted binary)</summary>
+    
+        ```bash
+        cargo binstall markdown-oxide
+        ```
+    
+    </details>
     
     - <details>
          <summary>AUR (from source)</summary>
@@ -175,6 +193,15 @@ For Helix, all you must do is install the language server's binary to your path.
     cargo install --locked --git https://github.com/Feel-ix-343/markdown-oxide.git markdown-oxide
     ```
 
+</details>
+
+- <details>
+    <summary>Cargo binstall (from hosted binary)</summary>
+    
+        ```bash
+        cargo binstall markdown-oxide
+        ```
+    
 </details>
 
 - <details>

--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ Markdown Oxide's features are implemented in the form of a language server aimin
          <summary>Cargo binstall (from hosted binary)</summary>
     
         ```bash
-        cargo binstall markdown-oxide
+        cargo binstall --git 'https://github.com/feel-ix-343/markdown-oxide' markdown-oxide
         ```
     
     </details>
@@ -123,6 +123,15 @@ Install the [vscode extension](https://marketplace.visualstudio.com/items?itemNa
         ```
     
     </details>
+
+    - <details>
+         <summary>Cargo binstall (from hosted binary)</summary>
+    
+        ```bash
+        cargo binstall --git 'https://github.com/feel-ix-343/markdown-oxide' markdown-oxide
+        ```
+    
+    </details>
     
     - <details>
          <summary>AUR (from source)</summary>
@@ -159,7 +168,7 @@ Markdown Oxide is available as an extension titled `Markdown Oxide`. Similarly t
          <summary>Cargo binstall (from hosted binary)</summary>
     
         ```bash
-        cargo binstall markdown-oxide
+        cargo binstall --git 'https://github.com/feel-ix-343/markdown-oxide' markdown-oxide
         ```
     
     </details>
@@ -199,7 +208,7 @@ For Helix, all you must do is install the language server's binary to your path.
     <summary>Cargo binstall (from hosted binary)</summary>
     
         ```bash
-        cargo binstall markdown-oxide
+        cargo binstall --git 'https://github.com/feel-ix-343/markdown-oxide' markdown-oxide
         ```
     
 </details>


### PR DESCRIPTION
This lets users install the binary directly instead of manually compiling it or grabbing the releases.

PS: You will have to update the version in the `Cargo.toml` file for new releases from now on! 