### PR TITLE
Implement filename extension in link completion

### DIFF
--- a/README.md
+++ b/README.md
@@ -551,6 +551,14 @@ new_file_folder_path = ""
 # This is also imported from obsidian if not specified: specifically the option titled "New file location"
 daily_notes_folder = ""
 
+
+# Whether markdown links should include an extension or not
+# for example [File](file.md) or [File](file)
+include_md_extension_md_link = false
+
+# Whether wikilinks should include an extension or not (needed for Markor compatibility)
+# for example [[File]] or [[File.md]]
+include_md_extension_wikilink = false
 ```
 
 

--- a/src/completion/link_completer.rs
+++ b/src/completion/link_completer.rs
@@ -153,9 +153,15 @@ impl<'a> LinkCompleter<'a> for MarkdownLinkCompleter<'a> {
 
     /// Will add <$1> to the refname if it contains spaces
     fn completion_text_edit(&self, display: Option<&str>, refname: &str) -> CompletionTextEdit {
+        let ext = if self.settings().include_md_extension_md_link {
+            ".md"
+        } else {
+            ""
+        };
+
         let link_ref_text = match refname.contains(' ') {
-            true => format!("<{}>", refname),
-            false => refname.to_owned(),
+            true => format!("<{}{}>", refname, ext),
+            false => format!("{}{}", refname, ext),
         };
 
         CompletionTextEdit::Edit(TextEdit {
@@ -347,6 +353,11 @@ impl<'a> LinkCompleter<'a> for WikiLinkCompleter<'a> {
     }
 
     fn completion_text_edit(&self, display: Option<&str>, refname: &str) -> CompletionTextEdit {
+        let ext = if self.settings().include_md_extension_wikilink {
+            ".md"
+        } else {
+            ""
+        };
         CompletionTextEdit::Edit(TextEdit {
             range: Range {
                 start: Position {
@@ -358,9 +369,11 @@ impl<'a> LinkCompleter<'a> for WikiLinkCompleter<'a> {
                     character: (self.chars_in_line).min(self.character + 2_u32),
                 },
             },
+
             new_text: format!(
-                "{}{}]]${{2:}}",
+                "{}{}{}]]${{2:}}",
                 refname,
+                ext,
                 display
                     .map(|display| format!("|{}", display))
                     .unwrap_or("".to_string())

--- a/src/config.rs
+++ b/src/config.rs
@@ -20,6 +20,8 @@ pub struct Settings {
     pub semantic_tokens: bool,
     pub tags_in_codeblocks: bool,
     pub references_in_codeblocks: bool,
+    pub include_md_extension_md_link: bool,
+    pub include_md_extension_wikilink: bool,
 }
 
 impl Settings {
@@ -57,6 +59,8 @@ impl Settings {
             .set_default("semantic_tokens", true)?
             .set_default("tags_in_codeblocks", true)?
             .set_default("references_in_codeblocks", true)?
+            .set_default("include_md_extension_md_link", false)?
+            .set_default("include_md_extension_wikilink", false)?
             .set_override_option(
                 "semantic_tokens",
                 capabilities.text_document.as_ref().and_then(|it| {


### PR DESCRIPTION
These changes add two options to the config file:

- `include_md_extension_md_link`
- `include_md_extension_wikilink`

These default to `false` in order to preserve past behavior. When set to `true` completions will include the file extension, this is needed for compatibility with other software:

- `[[wikilink.md]]`
    -  required by [Markor](https://github.com/gsantner/markor) on *Android*
- `[some-link](some-link.md)`
    -  required by WikiJS, Marktext and I'm sure many others.

This seeks to close #113.

Please let me know if there are any specific changes you would like made.
