### PR TITLE
chore(ci): sync Cargo version with release

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -52,6 +52,13 @@ jobs:
         shell: bash
         run: echo "VERSION=${GITHUB_REF#refs/tags/}" >> $GITHUB_ENV
 
+      - name: Update Cargo.toml with version number
+        shell: bash
+        run: |
+          sed --regexp-extended --in-place \
+            "s|^version = \"\\S+\"\|version = \"${VERSION}\"|" \
+            Cargo.toml
+
       - name: Build
         uses: actions-rs/cargo@v1
         with:

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -55,8 +55,11 @@ jobs:
       - name: Update Cargo.toml with version number
         shell: bash
         run: |
+          # strip leading "v" from tag
+          version_num="$(echo "${VERSION}" | cut --characters 2-)"
+          # edit version number in Cargo.toml
           sed --regexp-extended --in-place \
-            "s|^version = \"\\S+\"\|version = \"${VERSION}\"|" \
+            "s|^version = \"\\S+\"|version = \"${version_num}\"|" \
             Cargo.toml
 
       - name: Build

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -56,10 +56,11 @@ jobs:
         shell: bash
         run: |
           # strip leading "v" from tag
-          version_num="$(echo "${VERSION}" | cut --characters 2-)"
+          version_num="$(echo "${VERSION}" | cut -c 2-)"
           # edit version number in Cargo.toml
-          sed --regexp-extended --in-place \
-            "s|^version = \"\\S+\"|version = \"${version_num}\"|" \
+          sed -r \
+            -i.bak \
+            -e "s|^version = \"\\S+\"|version = \"${version_num}\"|" \
             Cargo.toml
 
       - name: Build

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "markdown-oxide"
-version = "0.24.0"
+version = "0.25.1"
 edition = "2021"
 repository = "https://github.com/Feel-ix-343/markdown-oxide"
 


### PR DESCRIPTION
Hi :wave:, it's me, the guy who [requested the `--version` command line argument](https://github.com/Feel-ix-343/markdown-oxide/issues/177). Thanks for that!

I'm looking at this project again and now would like to have up-to-date version information behind that flag.

This pull request:

* updates the version number in Cargo.toml
* adds a step to the deploy workflow that updates Cargo's version to match the current git tag

So hopefully after this, it's something you won't need to think about again. Whatever tag you push to GitHub, that's the version that will be reported when you do `--version`.

There are alternative approaches worth considering, however this is probably the least annoying, lowest-maintenance approach I can think of.

## Testing

I have tested this in my own fork by generating [this release](https://github.com/pcrockett/markdown-oxide/releases/tag/v0.25.2). However I only have a Linux system to test with, so I only downloaded the Linux binary to confirm the version number is correct. You may want to additionally check the version for macOS and Windows.