### PR TITLE
config: set {tags,references}_in_codeblocks to false by default

### DIFF
--- a/docs/Markdown Oxide Docs/Configuration.md
+++ b/docs/Markdown Oxide Docs/Configuration.md
@@ -26,9 +26,9 @@ unresolved_diagnostics = true
 semantic_tokens = true
 
 # Resolve tags in code blocks
-tags_in_codeblocks = true
+tags_in_codeblocks = false
 # Resolve references in code blocks
-references_in_codeblocks = true
+references_in_codeblocks = false
 
 # The folder for new files to be created in; this is relevant for the code action that creates
 # from an unresolved link. If not specified, it will import from your obsidian config option titled

--- a/src/config.rs
+++ b/src/config.rs
@@ -76,8 +76,8 @@ impl Settings {
             .set_default("unresolved_diagnostics", true)?
             .set_default("title_headings", true)?
             .set_default("semantic_tokens", true)?
-            .set_default("tags_in_codeblocks", true)?
-            .set_default("references_in_codeblocks", true)?
+            .set_default("tags_in_codeblocks", false)?
+            .set_default("references_in_codeblocks", false)?
             .set_default("include_md_extension_md_link", false)?
             .set_default("include_md_extension_wikilink", false)?
             .set_default("hover", true)?


### PR DESCRIPTION
According to the CommonMark specifications, code blocks content should be treated as literal text.