### PR TITLE
Update lockfile and add CI check

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -24,6 +24,6 @@ jobs:
     - name: Rustfmt Check
       uses: actions-rust-lang/rustfmt@v1
     - name: Build
-      run: cargo build --verbose
+      run: cargo build --verbose --locked
     - name: Run tests
       run: cargo test --verbose

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -802,7 +802,7 @@ dependencies = [
 
 [[package]]
 name = "markdown-oxide"
-version = "0.25.1"
+version = "0.25.3"
 dependencies = [
  "anyhow",
  "chrono",


### PR DESCRIPTION
`cargo install --locked` was failing because the lockfile was out of date.
This PR updates the lockfile, and adds a check to the CI workflow which fails if the lockfile is out of date.