### PR TITLE
Fix wiki link completions with heading + file extension.

### DIFF
--- a/src/completion/link_completer.rs
+++ b/src/completion/link_completer.rs
@@ -392,11 +392,17 @@ impl<'a> LinkCompleter<'a> for WikiLinkCompleter<'a> {
     }
 
     fn completion_text_edit(&self, display: Option<&str>, refname: &str) -> CompletionTextEdit {
-        let ext = if self.settings().include_md_extension_wikilink {
-            ".md"
+        let formatted_refname = if self.settings().include_md_extension_wikilink {
+            if let Some(hash_pos) = refname.find('#') {
+                let (filename, heading) = refname.split_at(hash_pos);
+                format!("{}.md{}", filename, heading)
+            } else {
+                format!("{}.md", refname)
+            }
         } else {
-            ""
+            refname.to_string()
         };
+
         CompletionTextEdit::Edit(TextEdit {
             range: Range {
                 start: Position {
@@ -410,9 +416,8 @@ impl<'a> LinkCompleter<'a> for WikiLinkCompleter<'a> {
             },
 
             new_text: format!(
-                "{}{}{}]]${{2:}}",
-                refname,
-                ext,
+                "{}{}]]${{2:}}",
+                formatted_refname,
                 display
                     .map(|display| format!("|{}", display))
                     .unwrap_or("".to_string())


### PR DESCRIPTION
Before, when the `include_md_extension_wikilink` flag was enabled, and a wikilink completion was accepted that contained a heading `bar`, the completion would look like `[[foo#bar.md]]`.

Now, instead, the same completion looks like `[[foo.md#bar]]`, correctly placing the file extension after the file name, and not the heading.

https://github.com/Feel-ix-343/markdown-oxide/pull/237 fixed this for normal links, i.e. with the `include_md_extension_md_link` flag, but it was never fixed for wikilinks.
