### PR TITLE
Update VS Code Extension project for local testing

### DIFF
--- a/vscode-extension/.vscode/launch.json
+++ b/vscode-extension/.vscode/launch.json
@@ -7,7 +7,7 @@
 			"request": "launch",
 			"name": "Launch Client",
 			"runtimeExecutable": "${execPath}",
-			"args": ["--extensionDevelopmentPath=${workspaceRoot}"],
+			"args": ["--disable-extensions", "--extensionDevelopmentPath=${workspaceRoot}"],
 			"outFiles": [
 				"${workspaceRoot}/client/out/**/*.js",
 				"${workspaceRoot}/server/out/**/*.js"

--- a/vscode-extension/client/src/extension.ts
+++ b/vscode-extension/client/src/extension.ts
@@ -169,7 +169,9 @@ export async function activate(context: ExtensionContext) {
 	// If the extension is launched in debug mode then the debug server options are used
 	// Otherwise the run options are used
 	const serverOptions: ServerOptions = {
-		command: path
+		// Use path to local binary for testing
+        // command: `/Users/xyz/workspace/markdown-oxide/target/release/markdown-oxide`,
+        command: path,
 		// run: { run: "/home/felix/coding/LargerIdeas/ObsidianLS/obsidian-ls/target/release/obsidian-ls", transport: TransportKind.ipc },
 		// debug: {
 		// 	module: serverModule,


### PR DESCRIPTION
When I worked on https://github.com/Feel-ix-343/markdown-oxide/pull/279, I found these changes to the VS Code Extension subfolder useful