### PR TITLE
Replace usage of deprecated get_active_clients() function

### DIFF
--- a/docs/Markdown Oxide Docs/README.md
+++ b/docs/Markdown Oxide Docs/README.md
@@ -139,7 +139,7 @@ Set up the PKM for your text editor...
 
         ```lua
         local function check_codelens_support()
-        local clients = vim.lsp.get_active_clients({ bufnr = 0 })
+        local clients = vim.lsp.get_clients({ bufnr = 0 })
         for _, c in ipairs(clients) do
           if c.server_capabilities.codeLensProvider then
             return true


### PR DESCRIPTION
Usage currently prints this in nvim 0.11.3:
```
WARNING vim.lsp.get_active_clients() is deprecated. Feature will be removed in Nvim 0.12
```
