### PR TITLE
fix: md link should not contain parentheses

### DIFF
--- a/src/vault/mod.rs
+++ b/src/vault/mod.rs
@@ -744,7 +744,7 @@ impl Reference {
             });
 
         static MD_LINK_RE: Lazy<Regex> = Lazy::new(|| {
-            Regex::new(r"\[(?<display>[^\[\]\.]*?)\]\(<?(?<filepath>(\.?\/)?[^\[\]\|\.\#<>]+?)?(?<ending>\.[^\# <>]+?)?(\#(?<infileref>[^\[\]\.\|<>]+?))?>?\)")
+            Regex::new(r"\[(?<display>[^\[\]\.]*?)\]\(<?(?<filepath>(\.?\/)?[^\[\]\|\.\#<>()]+?)?(?<ending>\.[^\# <>]+?)?(\#(?<infileref>[^\[\]\.\|<>()]+?))?>?\)")
                 .expect("MD Link Not Constructing")
         }); // [display](relativePath)
 

--- a/src/vault/mod.rs
+++ b/src/vault/mod.rs
@@ -2014,6 +2014,51 @@ mod vault_tests {
     }
 
     #[test]
+    fn md_empty_link_parsing() {
+        let text = "[]()";
+        let parsed = Reference::new(text, "test.md").collect_vec();
+
+        let expected = vec![Reference::MDFileLink(ReferenceData {
+            reference_text: "test.md".into(),
+            display_text: Some("".into()),
+            range: Range {
+                start: Position {
+                    line: 0,
+                    character: 0,
+                },
+                end: Position {
+                    line: 0,
+                    character: 4,
+                },
+            }
+            .into(),
+        })];
+
+        assert_eq!(parsed, expected);
+
+        let text = "[]()\n)";
+        let parsed = Reference::new(text, "test.md").collect_vec();
+
+        let expected = vec![Reference::MDFileLink(ReferenceData {
+            reference_text: "test.md".into(),
+            display_text: Some("".into()),
+            range: Range {
+                start: Position {
+                    line: 0,
+                    character: 0,
+                },
+                end: Position {
+                    line: 0,
+                    character: 4,
+                },
+            }
+            .into(),
+        })];
+
+        assert_eq!(parsed, expected);
+    }
+
+    #[test]
     fn footnote_link_parsing() {
         let text = "This is a footnote[^1]
 


### PR DESCRIPTION
Fixed an issue where a closing parenthesis following an empty markdown link would break the link (regardless of the `references_in_codeblocks` option).

Before (`references_in_codeblocks = false`):
<img width="427" height="287" alt="2025-08-19-231029-WezTerm" src="https://github.com/user-attachments/assets/93ee911a-86f1-4cb6-b0f5-d7f48e0e9986" />

After:
<img width="427" height="287" alt="2025-08-19-231008-WezTerm" src="https://github.com/user-attachments/assets/52351f00-5256-4314-b3a4-25874dfb8ba9" />
