### PR TITLE
Metadata with comments

### DIFF
--- a/src/vault/metadata.rs
+++ b/src/vault/metadata.rs
@@ -4,7 +4,10 @@ use serde::Deserialize;
 
 #[derive(Deserialize, Debug, Clone, Hash, PartialEq, Eq)]
 pub struct MDMetadata {
+    #[serde(default)]
     aliases: Vec<String>,
+    #[serde(default)]
+    comments: Vec<String>,
 }
 
 impl MDMetadata {
@@ -14,17 +17,39 @@ impl MDMetadata {
         static RE: Lazy<Regex> =
             Lazy::new(|| Regex::new(r"^---\n(?<metadata>(\n|.)*?)\n---").unwrap());
 
+        static COMMENT_RE: Lazy<Regex> = Lazy::new(|| {
+            Regex::new(r"(?m)(?:^[ \t]*#|\s#)\s*(?P<comment>[^\r\n]*)(?:\r?\n|$)").unwrap()
+        });
+
         let metadata_match = RE.captures_iter(text).next()?.name("metadata");
 
         let metadata_match = metadata_match?;
 
-        let md_metadata = serde_yaml::from_str::<MDMetadata>(metadata_match.as_str());
+        let metadata_str = metadata_match.as_str();
 
-        md_metadata.ok()
+        let md_metadata = serde_yaml::from_str::<MDMetadata>(metadata_str);
+
+        let comment_match = COMMENT_RE
+            .captures_iter(metadata_str)
+            .filter_map(|c| c.name("comment"))
+            .map(|i| i.as_str().into())
+            .collect::<Vec<_>>();
+
+        match md_metadata {
+            Ok(md) if md.aliases.is_empty() && comment_match.is_empty() => None,
+            Ok(mut md) => {
+                md.comments = comment_match;
+                Some(md)
+            }
+            Err(_) => None,
+        }
     }
 
     pub fn aliases(&self) -> &[String] {
         &self.aliases
+    }
+    pub fn comments(&self) -> &[String] {
+        &self.comments
     }
 }
 
@@ -49,5 +74,20 @@ aliases:
         )
         .unwrap();
         assert_eq!(metadata.aliases(), &["alias1", "alias2"]);
+    }
+
+    #[test]
+    fn test_alias_with_comments() {
+        let metadata = MDMetadata::new(
+            r"---
+aliases:
+    # Comment 1
+    - alias1
+    - alias2 # Comment 2
+---",
+        )
+        .unwrap();
+        assert_eq!(metadata.aliases(), vec!["alias1", "alias2"]);
+        assert_eq!(metadata.comments(), vec!["Comment 1", "Comment 2"]);
     }
 }

--- a/src/vault/mod.rs
+++ b/src/vault/mod.rs
@@ -568,8 +568,13 @@ impl MDFile {
                 .collect_vec(),
             _ => Reference::new(text, file_name).collect_vec(),
         };
-        let headings = MDHeading::new(text)
-            .filter(|it| !code_blocks.iter().any(|codeblock| codeblock.includes(it)));
+        let metadata = MDMetadata::new(text);
+        let headings = MDHeading::new(text).filter(|it| {
+            !code_blocks.iter().any(|codeblock| codeblock.includes(it))
+                && !metadata
+                    .iter()
+                    .any(|metadata| metadata.comments().contains(&it.heading_text))
+        });
         let footnotes = MDFootnote::new(text)
             .filter(|it| !code_blocks.iter().any(|codeblock| codeblock.includes(it)));
         let link_refs = MDLinkReferenceDefinition::new(text)
@@ -585,7 +590,6 @@ impl MDFile {
                 .collect_vec(),
             _ => MDTag::new(text).collect_vec(),
         };
-        let metadata = MDMetadata::new(text);
 
         MDFile {
             references: links,


### PR DESCRIPTION
Closes #261

**Some thoughts on the issue:**
Several Markdown implementations allow for an optional feature called [front matter](https://github.com/Kernix13/markdown-cheatsheet/blob/master/frontmatter.md), which allows the user to add metadata in YAML format at the start of a Markdown file, surrounded by three dashes.

`markdown-oxide` does support a small subset of it through its [alias feature](https://oxide.md/Features+Index), which allows a user to add alternative names to the current file. The issue occurs when a comment is present in the front matter section. YAML comments are captured as headings, which is not desired.

**Overview of the changes in this PR:**
- `src/vault/metadata.rs` was extended to allow the `MDMetadata` struct to hold comments.
- Tests were added to ensure that regular comments (on a newline) and inline comments were correctly captured.
- The method `MDFile::new()` on `src/vault/mod.rs` was modified: the metadata is captured before the headings, which are filtered to ignore headings that are actually metadata.

Edit: accidentally included an unwanted commit, will fix.
Edit: fixed.