### PR TITLE
feat (commands): add "create unique note" command

### DIFF
--- a/docs/Markdown Oxide Docs/Configuration.md
+++ b/docs/Markdown Oxide Docs/Configuration.md
@@ -66,6 +66,11 @@ block_transclusion = true
 # Full or Partial, for Partial, block_transclusion_length = { partial = 10 }
 # block_transclusion must be enabled for this to take effect
 block_transclusion_length = "Full"
+
+# Link file names only
+# Enables autocompleting by heading but inserting link to filename (instead of filename + heading)
+# Useful for unique notes / Zettelkasten users
+link_filenames_only = false
 ```
 
 # Daily Note Format Config Option

--- a/src/completion/link_completer.rs
+++ b/src/completion/link_completer.rs
@@ -160,7 +160,7 @@ impl<'a> LinkCompleter<'a> for MarkdownLinkCompleter<'a> {
         };
 
         let format_link = |name: &str, suffix: &str| {
-            if refname.contains(' ') {
+            if name.contains(' ') || suffix.contains(' ') {
                 format!("<{}{}{}>", name, ext, suffix)
             } else {
                 format!("{}{}{}", name, ext, suffix)

--- a/src/completion/link_completer.rs
+++ b/src/completion/link_completer.rs
@@ -170,11 +170,21 @@ impl<'a> LinkCompleter<'a> for MarkdownLinkCompleter<'a> {
         // Handle block links foobar#^123 -> foobar.md#^123
         let link_ref_text = if let Some(pos) = refname.find("#^") {
             let (name, suffix) = refname.split_at(pos);
-            format_link(name, suffix)
+
+            if self.settings().link_filenames_only {
+                format_link(name, "")
+            } else {
+                format_link(name, suffix)
+            }
         // Handle headings links foobar#myheading -> foobar.md#myheading
         } else if let Some(pos) = refname.find('#') {
             let (name, suffix) = refname.split_at(pos);
-            format_link(name, suffix)
+
+            if self.settings().link_filenames_only {
+                format_link(name, "")
+            } else {
+                format_link(name, suffix)
+            }
         } else {
             // default case foobar -> foobar.md
             format_link(refname, "")

--- a/src/config.rs
+++ b/src/config.rs
@@ -27,6 +27,7 @@ pub struct Settings {
     pub inlay_hints: bool,
     pub block_transclusion: bool,
     pub block_transclusion_length: EmbeddedBlockTransclusionLength,
+    pub link_filenames_only: bool,
 }
 
 #[derive(Clone, Debug, Deserialize)]
@@ -94,6 +95,7 @@ impl Settings {
                     }
                 }),
             )?
+            .set_default("link_filenames_only", false)?
             .build()
             .map_err(|err| anyhow!("Build err: {err}"))?;
 

--- a/src/config.rs
+++ b/src/config.rs
@@ -84,14 +84,8 @@ impl Settings {
                 "unique_notes_format",
                 obsidian_unique_note_config
                     .format
-                    .map(|v| {
-                        if v.len() > 0 {
-                            v
-                        } else {
-                            "%Y%m%d%H%M".to_string()
-                        }
-                    })
-                    .unwrap_or("%Y%m%d%h%m".to_string()),
+                    .filter(|v| v.len() > 0)
+                    .unwrap_or("%Y%m%d%H%M".to_string()),
             )?
             .set_default("heading_completions", true)?
             .set_default("unresolved_diagnostics", true)?

--- a/src/config.rs
+++ b/src/config.rs
@@ -74,6 +74,7 @@ impl Settings {
                 "dailynote",
                 obsidian_daily_note_config
                     .format
+                    .filter(|v| v.len() > 0)
                     .unwrap_or("%Y-%m-%d".to_string()),
             )?
             .set_default(

--- a/src/config.rs
+++ b/src/config.rs
@@ -14,6 +14,8 @@ pub struct Settings {
     /// Diffrent pages path than default
     pub new_file_folder_path: String,
     pub daily_notes_folder: String,
+    pub unique_notes_folder: String,
+    pub unique_notes_format: String,
     pub heading_completions: bool,
     pub title_headings: bool,
     pub unresolved_diagnostics: bool,
@@ -46,6 +48,7 @@ pub enum EmbeddedBlockTransclusionLength {
 impl Settings {
     pub fn new(root_dir: &Path, capabilities: &ClientCapabilities) -> anyhow::Result<Settings> {
         let obsidian_daily_note_config = obsidian_daily_note_config(root_dir).unwrap_or_default();
+        let obsidian_unique_note_config = obsidian_unique_note_config(root_dir).unwrap_or_default();
         let obsidian_new_file_folder_path = obsidian_new_file_folder_path(root_dir);
         let expanded = shellexpand::tilde("~/.config/moxide/settings");
         let settings = Config::builder()
@@ -72,6 +75,23 @@ impl Settings {
                 obsidian_daily_note_config
                     .format
                     .unwrap_or("%Y-%m-%d".to_string()),
+            )?
+            .set_default(
+                "unique_notes_folder",
+                obsidian_unique_note_config.folder.unwrap_or("".to_string()),
+            )?
+            .set_default(
+                "unique_notes_format",
+                obsidian_unique_note_config
+                    .format
+                    .map(|v| {
+                        if v.len() > 0 {
+                            v
+                        } else {
+                            "%Y%m%d%H%M".to_string()
+                        }
+                    })
+                    .unwrap_or("%Y%m%d%h%m".to_string()),
             )?
             .set_default("heading_completions", true)?
             .set_default("unresolved_diagnostics", true)?
@@ -117,6 +137,23 @@ fn obsidian_daily_note_config(root_dir: &Path) -> Option<ObsidianDailyNoteConfig
     let config: ObsidianDailyNoteConfig = serde_json::from_str(&file).ok()?;
 
     Some(ObsidianDailyNoteConfig {
+        folder: config.folder,
+        format: config.format.map(|x| convert_momentjs_to_chrono_format(&x)),
+    })
+}
+
+#[derive(Deserialize, Debug, Default)]
+struct ObsidianUniqueNoteConfig {
+    folder: Option<String>,
+    format: Option<String>,
+}
+
+fn obsidian_unique_note_config(root_dir: &Path) -> Option<ObsidianUniqueNoteConfig> {
+    let unique_notes_config_file = root_dir.join(".obsidian").join("zk-prefixer.json");
+    let file = std::fs::read_to_string(unique_notes_config_file).ok()?;
+    let config: ObsidianUniqueNoteConfig = serde_json::from_str(&file).ok()?;
+
+    Some(ObsidianUniqueNoteConfig {
         folder: config.folder,
         format: config.format.map(|x| convert_momentjs_to_chrono_format(&x)),
     })

--- a/src/main.rs
+++ b/src/main.rs
@@ -378,6 +378,7 @@ impl LanguageServer for Backend {
                 execute_command_provider: Some(ExecuteCommandOptions {
                     commands: vec![
                         "apply_edits".into(),
+                        "create_unique_note".into(),
                         "jump".into(),
                         "tomorrow".into(),
                         "today".into(),
@@ -614,6 +615,15 @@ impl LanguageServer for Backend {
                 }
 
                 Ok(None)
+            }
+            ExecuteCommandParams { command, .. } if *command == *"create_unique_note" => {
+                let settings = self
+                    .bind_settings(|settings| Ok(settings.to_owned()))
+                    .await?;
+                let root_dir = self
+                    .bind_vault(|vault| Ok(vault.root_dir().to_owned()))
+                    .await?;
+                commands::create_unique_note(&self.client, &root_dir, &settings).await
             }
             ExecuteCommandParams { command, .. } if *command == *"jump" => {
                 let jump_to = params.arguments.first().and_then(|val| val.as_str());

--- a/src/main.rs
+++ b/src/main.rs
@@ -36,6 +36,7 @@ mod symbol;
 mod tokens;
 mod ui;
 mod vault;
+mod unique_notes;
 
 #[derive(Debug)]
 struct Backend {

--- a/src/unique_notes.rs
+++ b/src/unique_notes.rs
@@ -1,0 +1,113 @@
+use std::path::{Path, PathBuf};
+
+use chrono::NaiveDateTime;
+
+pub trait NowProvider {
+    fn now(&self) -> NaiveDateTime;
+}
+
+pub trait CreateFileProvider<File, Err> {
+    fn create_file(&self, path: &Path) -> Result<File, Err>;
+}
+
+pub fn find_unique_file_path<T: NowProvider>(
+    folder: &PathBuf,
+    format: &str,
+    now_provider: &T,
+) -> PathBuf {
+    let now = now_provider.now();
+
+    let filename = now.format(format).to_string();
+    let extension = "md";
+
+    find_unique_file_path_rec(folder.into(), filename, extension, None)
+}
+
+fn find_unique_file_path_rec(
+    path: PathBuf,
+    filename: String,
+    extension: &str,
+    postfix: Option<i32>,
+) -> PathBuf {
+    let curr_filename = format!(
+        "{}{}",
+        filename,
+        postfix.map_or("".to_string(), |n| n.to_string())
+    );
+
+    let filepath = path.join(&curr_filename).with_extension(extension);
+
+    if filepath.exists() {
+        find_unique_file_path_rec(
+            path,
+            filename,
+            extension,
+            postfix.map_or(Some(0), |n| Some(n + 1)),
+        )
+    } else {
+        filepath
+    }
+}
+
+pub fn create_unique_note<
+    File,
+    Err: std::fmt::Debug,
+    T: NowProvider + CreateFileProvider<File, Err>,
+>(
+    folder: &PathBuf,
+    format: &str,
+    ctx: &T,
+) -> PathBuf {
+    let file_path = find_unique_file_path(folder, format, ctx);
+
+    // file creation can fail and return an Err, ignore this and try
+    // to open the file on the off chance the client knows what to do
+    // TODO: log failure to create file
+    let _ = file_path.parent().map(std::fs::create_dir_all).unwrap();
+
+    let _ = ctx.create_file(file_path.as_path()).unwrap();
+
+    file_path
+}
+
+#[cfg(test)]
+mod tests {
+    use std::path::PathBuf;
+
+    use chrono::NaiveDateTime;
+
+    use crate::unique_notes::{CreateFileProvider, NowProvider};
+
+    use super::create_unique_note;
+
+    struct TestCtx {
+        time: NaiveDateTime,
+    }
+
+    impl NowProvider for TestCtx {
+        fn now(&self) -> NaiveDateTime {
+            self.time
+        }
+    }
+
+    impl CreateFileProvider<(), ()> for TestCtx {
+        fn create_file(&self, _path: &std::path::Path) -> Result<(), ()> {
+            Ok(())
+        }
+    }
+
+    #[test]
+    fn test_create_unique_note() {
+        let folder = PathBuf::from(r"TestFiles/");
+        let format = "%Y%m%d%H%M%S";
+        let test_ctx = TestCtx {
+            time: "2025-05-05T13:01:57".parse::<NaiveDateTime>().unwrap(),
+        };
+
+        let expected = PathBuf::from("TestFiles/20250505130157.md");
+
+        let actual = create_unique_note(&folder, format, &test_ctx);
+
+        assert_eq!(actual, expected);
+    }
+}


### PR DESCRIPTION
Adds an lsp command similar to obsidian's "unique note" builtin feature, which creates a new note file with a unique name based on a "unique note format" setting configured similar to the "daily note" setting. This change also skips "unique" file names that already exist by appending an incremental number to the note name to avoid conflicts, just as obsidian does.