### PR TITLE
FEAT: Add support for lsp moving files; fix rename

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -814,6 +814,7 @@ dependencies = [
  "nanoid",
  "nucleo-matcher",
  "once_cell",
+ "path-clean",
  "pathdiff",
  "rayon",
  "regex",
@@ -951,6 +952,12 @@ dependencies = [
  "smallvec",
  "windows-targets 0.52.6",
 ]
+
+[[package]]
+name = "path-clean"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "17359afc20d7ab31fdb42bb844c8b3bb1dabd7dcf7e68428492da7f16966fcef"
 
 [[package]]
 name = "pathdiff"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,6 +29,7 @@ tower-lsp = { git = "https://github.com/Feel-ix-343/tower-lsp" }
 walkdir = "2.4.0"
 do-notation = "0.1.3"
 urlencoding = "2.1.3"
+path-clean = "1.0.1"
 
 [package.metadata.binstall]
 pkg-url = "{ repo }/releases/download/v{ version }/{ name }-v{ version }-{ target }{ archive-suffix }"

--- a/src/main.rs
+++ b/src/main.rs
@@ -367,6 +367,7 @@ impl LanguageServer for Backend {
                     file_operations: Some(WorkspaceFileOperationsServerCapabilities {
                         did_create: Some(file_op_reg.clone()),
                         did_rename: Some(file_op_reg.clone()),
+                        will_rename: Some(file_op_reg.clone()),
                         did_delete: Some(file_op_reg.clone()),
                         ..Default::default()
                     }),
@@ -665,6 +666,11 @@ impl LanguageServer for Backend {
             Ok(rename::rename(vault, &params, &path))
         })
         .await
+    }
+
+    async fn will_rename_files(&self, params: RenameFilesParams) -> Result<Option<WorkspaceEdit>> {
+        self.bind_vault(|vault| Ok(Some(rename::rename_files(vault, &params))))
+            .await
     }
 
     async fn code_action(&self, params: CodeActionParams) -> Result<Option<CodeActionResponse>> {

--- a/src/vault/mod.rs
+++ b/src/vault/mod.rs
@@ -159,6 +159,13 @@ impl Vault {
         }
     }
 
+    pub fn select_referenceable_path<'a>(&'a self, path: &'a Path) -> Option<Referenceable<'a>> {
+        self.md_files
+            .iter()
+            .find(|(iterpath, _)| *iterpath == path)
+            .map(|(pathbuf, mdfile)| Referenceable::File(pathbuf, mdfile))
+    }
+
     pub fn select_referenceable_at_position<'a>(
         &'a self,
         path: &'a Path,
@@ -180,11 +187,7 @@ impl Vault {
             .map(|tupl| tupl.0);
 
         match referenceable {
-            None => self
-                .md_files
-                .iter()
-                .find(|(iterpath, _)| *iterpath == path)
-                .map(|(pathbuf, mdfile)| Referenceable::File(pathbuf, mdfile)),
+            None => self.select_referenceable_path(path),
             _ => referenceable,
         }
     }


### PR DESCRIPTION

When renaming files with `textDocument/rename`, when changing the route of the file, the references would brake.
for example:
```
.
├── dir1/
│   ├── subdir/
│   └── note.md
└── ref.md // contains [[dir1/note.md]] or similar
```
if I rename (move) `note.md` to `subdir/note.md`, the `ref.md`'s reference would have changed to `[[subdir/note.md]]`.

With this PR, the reference would become `[[dir1/subdir/note.md]]`.

Another useful thing that this PR provides is the ability to move files with the LSP (`workspace/willRenameFiles`),
which allows for editors that support this feature (`oil.nvim` for example) to move files normally while the LSP keeps track of references.

I am honestly not super familiar with the LSP protocol or this project, any feedback is welcome