### PR TITLE
Delete What Is Markdown-Oxide.md and update navigation

### DIFF
--- a/docs/Markdown Oxide Docs/What Is Markdown-Oxide.md
+++ b/docs/Markdown Oxide Docs/What Is Markdown-Oxide.md
@@ -1,9 +1,0 @@
-# What is Markdown-Oxide?
-
-- ^whatIsMarkdownOxide
-
-    # What is Markdown-Oxide
-    
-    Markdown-Oxide is a Personal Knowledge Management System (PKMS) that composes with your favorite text-editor through the Language Server Protocol (LSP).
-    
-    While other PKMS implementations include their own text-editors, markdown-oxide is *unbundled*: it leaves text-editing to a dedicated text-editor and focuses solely on robust, performant knowledge management.

--- a/docs/Markdown Oxide Docs/index.md
+++ b/docs/Markdown Oxide Docs/index.md
@@ -1,8 +1,10 @@
 # Markdown-Oxide
 
-![[What Is Markdown-Oxide#^whatIsMarkdownOxide]]
+Markdown-Oxide is a Personal Knowledge Management System (PKMS) that composes with your favorite text-editor through the Language Server Protocol (LSP).
 
-It also is inspired by and highly compatible with Obsidian. 
+While other PKMS implementations include their own text-editors, markdown-oxide is *unbundled*: it leaves text-editing to a dedicated text-editor and focuses solely on robust, performant knowledge management.
+
+It also is inspired by and highly compatible with Obsidian.
 
 > [!note] Editor Support
 > The best-supported text editor is Neovim, but also popular with users are VSCode, Helix, and Zed.

--- a/docs/docs.json
+++ b/docs/docs.json
@@ -45,31 +45,25 @@
         "group": "Get Started",
         "pages": [
           "index",
-          "what-is-markdown-oxide",
           "setup-instructions"
         ]
       },
       {
         "group": "Features",
         "pages": [
-          "features-index",
-          "daily-notes"
+          "features-index"
         ]
       },
       {
         "group": "Configuration",
         "pages": [
-          "configuration",
-          "date-formatting"
+          "configuration"
         ]
       },
       {
         "group": "Reference",
         "pages": [
-          "reference/readme",
-          "reference/lsp",
-          "reference/pkms",
-          "reference/author"
+          "reference/readme"
         ]
       }
     ]


### PR DESCRIPTION
# Delete What Is Markdown-Oxide.md and update navigation

## Summary
This PR completes the documentation cleanup started in PR #309 by:
- Deleting the `What Is Markdown-Oxide.md` standalone article
- Inlining its content directly into `index.md` to preserve the information
- Updating `docs.json` navigation to remove links to all deleted documentation pages

The navigation now reflects the streamlined documentation structure with 6 pages removed: `what-is-markdown-oxide`, `daily-notes`, `date-formatting`, `reference/lsp`, `reference/pkms`, and `reference/author` (the latter 5 were deleted in PR #309).

## Review & Testing Checklist for Human
- [ ] **Verify navigation changes are complete** - Check that all 6 removed pages (what-is-markdown-oxide, daily-notes, date-formatting, reference/lsp, reference/pkms, reference/author) should indeed be removed from navigation
- [ ] **Test preview deployment** - Browse through the Mintlify preview to ensure no 404 errors or broken navigation links
- [ ] **Verify content flow in index.md** - Confirm that inlining the PKMS/LSP definitions reads naturally and fits well with the rest of the introduction

### Notes
- This PR follows up on PR #309 which deleted 5 other documentation articles
- All content has been preserved by inlining into parent documents
- CI checks passed locally (cargo clippy, cargo fmt, cargo test)
- Net documentation reduction continues the cleanup from PR #309
- This PR was created by Devin for Felix Zeller (felix@exa.ai / @Feel-ix-343)
- Link to Devin run: https://app.devin.ai/sessions/21bff64f2dbe46c8892fc79317adcea6