### PR TITLE
Add Zed extension marketplace link to installation docs

### DIFF
--- a/docs/getting-started.mdx
+++ b/docs/getting-started.mdx
@@ -195,11 +195,11 @@ If you want to install to your path, use one of the following methods:
 
 ### Zed
 
-Markdown Oxide is available as an extension titled `Markdown Oxide`. Similarly to VSCode, there are two methods for this extension to access the language server:
-- **Recommended:** the extension will download the server's binary and use that
-- The extension will use `markdown-oxide` from path
+Install the [Markdown Oxide extension](https://extensions.zed.dev/extensions/markdown-oxide) from Zed's extension marketplace.
 
-If you want to install to your path, use one of the following methods:
+The extension will automatically download and manage the language server binary.
+
+Alternatively, you can install the language server to your path using one of the following methods:
 
 <AccordionGroup>
   <Accordion title="Cargo Install (from source)">


### PR DESCRIPTION
# Add Zed extension marketplace link to installation docs

## Summary
Updated the Zed section in the getting-started documentation to include a direct link to the [Zed extension marketplace](https://extensions.zed.dev/extensions/markdown-oxide) and clarified that the extension automatically downloads and manages the language server binary. This makes it clearer for users how to get started with Markdown Oxide in Zed.

## Review & Testing Checklist for Human
- [ ] Verify the Zed extension marketplace link (https://extensions.zed.dev/extensions/markdown-oxide) is correct and accessible
- [ ] Check that the documentation renders correctly on the docs site

### Notes
- This is a documentation-only change with no code modifications
- All lint checks and tests pass
- Link to Devin run: https://app.devin.ai/sessions/bd1f977cd32c41f78d60a44aeb1d8da9
- Requested by: Felix Zeller (felix@exa.ai) / @Feel-ix-343
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/feel-ix-343/markdown-oxide/pull/313" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
