### PR TITLE
Fix Mintlify branding: replace 'Mint Starter Kit' with 'Feel-ix-343 / markdown-oxide'

### DIFF
--- a/docs/docs.json
+++ b/docs/docs.json
@@ -1,11 +1,6 @@
 {
-  "name": "Markdown-Oxide",
+  "name": "Feel-ix-343 / markdown-oxide",
   "theme": "mint",
-  "logo": {
-    "dark": "/logo/dark.svg",
-    "light": "/logo/light.svg"
-  },
-  "favicon": "/favicon.svg",
   "colors": {
     "primary": "#2563EB",
     "light": "#60A5FA",


### PR DESCRIPTION
# Fix Mintlify branding: replace 'Mint Starter Kit' with 'Feel-ix-343 / markdown-oxide'

## Summary
Removed broken logo and favicon references from `docs/docs.json` that were causing Mintlify to fall back to its default "Mint Starter Kit" branding. Updated the site name to "Feel-ix-343 / markdown-oxide" to display the correct branding.

The logo files referenced in the config (`/logo/dark.svg`, `/logo/light.svg`, `/favicon.svg`) don't exist in the repository, which causes Mintlify to show its default starter kit branding instead of the intended site name.

## Review & Testing Checklist for Human
- [ ] **Deploy and verify**: Check that the Mintlify documentation site now displays "Feel-ix-343 / markdown-oxide" in the header instead of "Mint Starter Kit"
- [ ] **Confirm intent**: Verify this matches your desired branding (text-only vs. custom logo with GitHub icon)
- [ ] **Visual check**: Ensure the header looks correct in both light and dark themes

### Test Plan
1. Deploy the changes to the Mintlify site (or check the preview deployment if available)
2. Visit the documentation site and verify the header shows "Feel-ix-343 / markdown-oxide"
3. Toggle between light/dark themes to ensure branding displays correctly in both

### Notes
- This change removes the logo/favicon configuration entirely and relies on the `name` field for branding
- If you want a custom logo with the GitHub icon (as shown in your second image), we would need to create the actual SVG files and add them to the repository
- JSON syntax has been validated

---
**Session**: https://app.devin.ai/sessions/15148cbc932f402da4b56e4790381729  
**Requested by**: Felix Zeller (felix@exa.ai) / @Feel-ix-343
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/feel-ix-343/markdown-oxide/pull/314" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
