### PR TITLE
Add relative directive support to Daily notes command

### DIFF
--- a/docs/Markdown Oxide Docs/.trash/Features/Daily Notes.md
+++ b/docs/Markdown Oxide Docs/.trash/Features/Daily Notes.md
@@ -187,12 +187,21 @@ Instead of memorizing this, however, I'd recommend just trying relative names ou
 Here are some examples for neovim daily note commands (as specified in the setup [here](README#^nvimconfigsetup)
 
 - examples ^nvimrelativenamescmds
-    * `:Daily two days ago`
-    * `:Daily 2 days ago`
-    * `:Daily next monday`
-    * `:Daily last friday`
-    * `:Daily today`
-    * `:Daily tomorrow`
+    * Natural language:
+        + `:Daily two days ago`
+        + `:Daily 2 days ago`
+        + `:Daily next monday`
+        + `:Daily last friday`
+        + `:Daily today`
+        + `:Daily tomorrow`
+    * Relative directives:
+        + `:Daily prev` - previous day
+        + `:Daily next` - next day
+        + `:Daily +1` - tomorrow (1 day forward)
+        + `:Daily -1` - yesterday (1 day backward)
+        + `:Daily +7` - one week forward
+        + `:Daily -7` - one week backward
+        + `:Daily +30` - 30 days forward
 
 ### Other
 

--- a/docs/Markdown Oxide Docs/Configuration.md
+++ b/docs/Markdown Oxide Docs/Configuration.md
@@ -37,7 +37,7 @@ new_file_folder_path = ""
 
 
 # The folder for new daily notes: this is applied for the create file for unresolved link code action
-# as well as the Today, Tomorrow, Yesterday, and Daily... lsp commands
+# as well as the Today, Tomorrow, Yesterday, and Daily... lsp commands (including relative directives like prev, next, +N, -N)
 #
 # This is also imported from obsidian if not specified: specifically the option titled "New file location"
 daily_notes_folder = ""

--- a/docs/Markdown Oxide Docs/Features Index.md
+++ b/docs/Markdown Oxide Docs/Features Index.md
@@ -272,6 +272,14 @@ When clicking on each drop-down, you will be presented with a demo of the featur
             - `:Daily last friday`
             - `:Daily today`
             - `:Daily tomorrow`
+    * Open or create daily notes using relative directives for quick navigation:
+        + `:Daily prev` - previous day
+        + `:Daily next` - next day
+        + `:Daily +1` - tomorrow (1 day forward)
+        + `:Daily -1` - yesterday (1 day backward)
+        + `:Daily +7` - one week forward
+        + `:Daily -7` - one week backward
+        + `:Daily +30` - 30 days forward
     * Open or create daily notes through predefined relative names.  `:Today`
         + The predefined relative names are: `today`, `tomorrow`, `yesterday`, `next {monday,tuesday,..., sunday}`, `last {monday,tuesday,...}`
         + Each of these names have their own workspace commands

--- a/docs/Markdown Oxide Docs/README.md
+++ b/docs/Markdown Oxide Docs/README.md
@@ -157,7 +157,11 @@ Set up the PKM for your text editor...
     - <details>
         <summary>(optional) Enable opening daily notes with natural language</summary>
 
-        Modify your lsp `on_attach` function to support opening daily notes with, for example, `:Daily two days ago` or `:Daily next monday`. 
+        Modify your lsp `on_attach` function to support opening daily notes with natural language and relative directives.
+
+        Examples:
+        - Natural language: `:Daily two days ago`, `:Daily next monday`
+        - Relative directives: `:Daily prev`, `:Daily next`, `:Daily +7`, `:Daily -3`
 
         ```lua
         -- setup Markdown Oxide daily note commands

--- a/docs/getting-started.mdx
+++ b/docs/getting-started.mdx
@@ -124,7 +124,11 @@ Give Neovim access to the binary using one of the following installation methods
   </Accordion>
 
   <Accordion title="(optional) Enable opening daily notes with natural language">
-    Modify your lsp `on_attach` function to support opening daily notes with, for example, `:Daily two days ago` or `:Daily next monday`. 
+    Modify your lsp `on_attach` function to support opening daily notes with natural language and relative directives. 
+
+    Examples:
+    - Natural language: `:Daily two days ago`, `:Daily next monday`
+    - Relative directives: `:Daily prev`, `:Daily next`, `:Daily +7`, `:Daily -3`
 
     ```lua
     -- setup Markdown Oxide daily note commands

--- a/docs/index.mdx
+++ b/docs/index.mdx
@@ -78,7 +78,7 @@ Manage your daily journal with natural language commands.
 
 <AccordionGroup>
 <Accordion title="Natural Language Navigation & Smart Completions">
-Open notes with commands like `:Daily next monday` or `:Daily two days ago`. Link to daily notes using relative dates like `[[tomorrow]]` or `[[next friday]]`.
+Open notes with commands like `:Daily next monday` or `:Daily two days ago`. Use relative directives like `:Daily prev`, `:Daily next`, `:Daily +7`, or `:Daily -3` to navigate forward and backward. Link to daily notes using relative dates like `[[tomorrow]]` or `[[next friday]]`.
 
 ![dailynoteswiki](https://github.com/Feel-ix-343/markdown-oxide/assets/88951499/d2505535-ef5e-491a-bd88-ef12be2402ef)
 </Accordion>

--- a/src/commands.rs
+++ b/src/commands.rs
@@ -3,7 +3,7 @@ use std::path::Path;
 
 use crate::config::Settings;
 use chrono::offset::Local;
-use chrono::NaiveDateTime;
+use chrono::{Days, NaiveDate, NaiveDateTime};
 use fuzzydate::parse;
 use serde_json::Value;
 use tower_lsp::jsonrpc::{Error, Result};
@@ -20,20 +20,63 @@ fn datetime_to_file(
     Url::from_file_path(path.with_extension("md")).ok()
 }
 
+fn date_to_file(date: NaiveDate, dailynote_format: &str, root_dir: &Path) -> Option<Url> {
+    let filename = date.format(dailynote_format).to_string();
+    let path = root_dir.join(&filename);
+
+    Url::from_file_path(path.with_extension("md")).ok()
+}
+
+fn extract_date_from_filename(filename: &str, dailynote_format: &str) -> Option<NaiveDate> {
+    let filename = filename.strip_suffix(".md").unwrap_or(filename);
+    NaiveDate::parse_from_str(filename, dailynote_format).ok()
+}
+
+fn parse_relative_directive(input: &str) -> Option<i64> {
+    let trimmed = input.trim();
+
+    match trimmed {
+        "prev" => Some(-1),
+        "next" => Some(1),
+        _ => {
+            if let Some(stripped) = trimmed.strip_prefix('+') {
+                stripped.parse::<i64>().ok()
+            } else if let Some(stripped) = trimmed.strip_prefix('-') {
+                stripped.parse::<i64>().ok().map(|n| -n)
+            } else {
+                trimmed.parse::<i64>().ok()
+            }
+        }
+    }
+}
+
 pub async fn jump(
     client: &tower_lsp::Client,
     root_dir: &Path,
     settings: &Settings,
     jump_to: Option<&str>,
 ) -> Result<Option<Value>> {
-    // if jump_to is None, use the current time.
-
     let daily_note_format = &settings.dailynote;
     let daily_note_path = root_dir.join(&settings.daily_notes_folder);
+
     let note_file = match jump_to {
-        Some(jmp_str) => parse(jmp_str)
-            .ok()
-            .and_then(|dt| datetime_to_file(dt, daily_note_format, &daily_note_path)),
+        Some(jmp_str) => {
+            if let Some(offset) = parse_relative_directive(jmp_str) {
+                let base_date = Local::now().date_naive();
+
+                let target_date = if offset >= 0 {
+                    base_date.checked_add_days(Days::new(offset as u64))
+                } else {
+                    base_date.checked_sub_days(Days::new((-offset) as u64))
+                };
+
+                target_date.and_then(|date| date_to_file(date, daily_note_format, &daily_note_path))
+            } else {
+                parse(jmp_str)
+                    .ok()
+                    .and_then(|dt| datetime_to_file(dt, daily_note_format, &daily_note_path))
+            }
+        }
         None => datetime_to_file(
             Local::now().naive_local(),
             daily_note_format,
@@ -42,9 +85,6 @@ pub async fn jump(
     };
 
     if let Some(uri) = note_file {
-        // file creation can fail and return an Err, ignore this and try
-        // to open the file on the off chance the client knows what to do
-        // TODO: log failure to create file
         let _ = uri.to_file_path().map(|path| {
             path.parent().map(std::fs::create_dir_all);
 
@@ -74,12 +114,12 @@ pub async fn jump(
     }
 }
 
-// tests
 #[cfg(test)]
 mod tests {
+    use chrono::NaiveDate;
     use fuzzydate::parse;
 
-    use super::datetime_to_file;
+    use super::{datetime_to_file, extract_date_from_filename, parse_relative_directive};
 
     #[test]
     fn test_string_to_file() {
@@ -93,5 +133,60 @@ mod tests {
             &std::fs::canonicalize("./").unwrap(),
         )
         .unwrap();
+    }
+
+    #[test]
+    fn test_parse_relative_directive_prev() {
+        assert_eq!(parse_relative_directive("prev"), Some(-1));
+    }
+
+    #[test]
+    fn test_parse_relative_directive_next() {
+        assert_eq!(parse_relative_directive("next"), Some(1));
+    }
+
+    #[test]
+    fn test_parse_relative_directive_plus() {
+        assert_eq!(parse_relative_directive("+1"), Some(1));
+        assert_eq!(parse_relative_directive("+7"), Some(7));
+        assert_eq!(parse_relative_directive("+30"), Some(30));
+    }
+
+    #[test]
+    fn test_parse_relative_directive_minus() {
+        assert_eq!(parse_relative_directive("-1"), Some(-1));
+        assert_eq!(parse_relative_directive("-7"), Some(-7));
+        assert_eq!(parse_relative_directive("-30"), Some(-30));
+    }
+
+    #[test]
+    fn test_parse_relative_directive_plain_number() {
+        assert_eq!(parse_relative_directive("1"), Some(1));
+        assert_eq!(parse_relative_directive("7"), Some(7));
+    }
+
+    #[test]
+    fn test_parse_relative_directive_invalid() {
+        assert_eq!(parse_relative_directive("invalid"), None);
+        assert_eq!(parse_relative_directive("next monday"), None);
+        assert_eq!(parse_relative_directive(""), None);
+    }
+
+    #[test]
+    fn test_extract_date_from_filename() {
+        let date = extract_date_from_filename("2024-11-09.md", "%Y-%m-%d");
+        assert_eq!(date, Some(NaiveDate::from_ymd_opt(2024, 11, 9).unwrap()));
+
+        let date = extract_date_from_filename("2024-11-09", "%Y-%m-%d");
+        assert_eq!(date, Some(NaiveDate::from_ymd_opt(2024, 11, 9).unwrap()));
+    }
+
+    #[test]
+    fn test_extract_date_from_filename_invalid() {
+        let date = extract_date_from_filename("not-a-date.md", "%Y-%m-%d");
+        assert_eq!(date, None);
+
+        let date = extract_date_from_filename("2024-13-01.md", "%Y-%m-%d");
+        assert_eq!(date, None);
     }
 }


### PR DESCRIPTION
# Add relative directive support to Daily notes command

## Summary
Implements relative directive support for the Daily notes command, allowing users to navigate daily notes using simple syntax like `:Daily prev`, `:Daily next`, `:Daily +7`, `:Daily -3` in addition to the existing natural language support (`:Daily next monday`, `:Daily two days ago`).

**Changes:**
- **Rust implementation** (`src/commands.rs`):
  - Added `parse_relative_directive()` function to parse `prev`, `next`, `+N`, `-N` syntax
  - Modified `jump()` function to try directive parsing before falling back to fuzzydate
  - Added helper functions `date_to_file()` and `extract_date_from_filename()`
  - Added 8 comprehensive unit tests for directive parsing and date extraction
  
- **Documentation updates** (6 files):
  - Updated all documentation files with examples of relative directives
  - Added examples for Neovim users showing both natural language and relative directive syntax
  - Updated configuration documentation to mention relative directives

**Behavior:**
- Relative directives navigate from today's date (using `Local::now().date_naive()`)
- Falls back to existing fuzzydate parsing for natural language input
- Maintains full backward compatibility with existing commands

## Review & Testing Checklist for Human

- [ ] **Verify requirement interpretation**: The issue #296 text wasn't accessible, so I inferred the requirement from documentation. Please confirm that navigating relative to *today* (not the currently open daily note) is the intended behavior.

- [ ] **Test end-to-end in Neovim**: Run commands like `:Daily prev`, `:Daily next`, `:Daily +7`, `:Daily -3` to verify they work correctly and create/open the expected daily notes.

- [ ] **Test backward compatibility**: Verify existing natural language commands still work (`:Daily next monday`, `:Daily two days ago`, etc.).

- [ ] **Review unused function**: The `extract_date_from_filename()` function is currently unused (clippy warning). Should it be removed, or is it intended for future use (e.g., navigating relative to the currently open daily note)?

- [ ] **Test edge cases**: Try commands at timezone boundaries (e.g., just before/after midnight) to ensure date calculations are correct.

### Notes
- All existing tests pass (`cargo test`)
- Code formatted with `cargo fmt`
- Clippy shows one warning about unused `extract_date_from_filename` function (see checklist item #4)
- The old Daily Notes documentation mentioned a future feature for "prev/next dailynote" relative to the currently opened note - this PR implements navigation relative to today instead

**Session info:**
- Requested by: Felix Zeller (felix@exa.ai) / @Feel-ix-343
- Devin session: https://app.devin.ai/sessions/e422286e8ecd46a1a6a0f2521df75214