### PR TITLE
fix(vault): use MAIN_SEPARATOR for path splitting

### DIFF
--- a/src/vault/mod.rs
+++ b/src/vault/mod.rs
@@ -7,7 +7,7 @@ use std::{
     hash::Hash,
     iter,
     ops::{Deref, DerefMut, Not, Range},
-    path::{Path, PathBuf},
+    path::{Path, PathBuf, MAIN_SEPARATOR},
     time::SystemTime,
 };
 
@@ -1385,7 +1385,7 @@ impl Refname {
     pub fn link_file_key(&self) -> Option<String> {
         let path = &self.path.clone()?;
 
-        let last = path.split('/').next_back()?;
+        let last = path.split(MAIN_SEPARATOR).next_back()?;
 
         Some(last.to_string())
     }


### PR DESCRIPTION
fix https://github.com/Feel-ix-343/markdown-oxide/issues/243

On Windows, we've switched to using `\` for path separators.

NOTE: Obsidian's wikilinks and tags only accept “/” (for example, `[[foo/bar]]` is OK for referencing foo/bar.md, but `[[foo\bar]]` is NG), so use `std::path::MAIN_SEPARATOR` only for splitting files.

before|after
-|-
<img width="859" height="712" alt="image" src="https://github.com/user-attachments/assets/59894771-b923-4156-ae03-3bd9bd857d2d" />|<img width="769" height="711" alt="image" src="https://github.com/user-attachments/assets/49982f9b-87d6-464f-b55e-14799e0f8162" />
