### PR TITLE
Add callout_completions setting to selectively disable callout completions

### DIFF
--- a/src/completion/callout_completer.rs
+++ b/src/completion/callout_completer.rs
@@ -19,6 +19,10 @@ impl<'a> Completer<'a> for CalloutCompleter {
     where
         Self: Sized + Completer<'a>,
     {
+        if !context.settings.callout_completions {
+            return None;
+        }
+
         let line_chars = context.vault.select_line(context.path, line as isize)?;
 
         static PARTIAL_CALLOUT: Lazy<Regex> =

--- a/src/completion/mod.rs
+++ b/src/completion/mod.rs
@@ -106,15 +106,11 @@ pub fn get_completions(
         )
     })
     .or_else(|| {
-        if config.callout_completions {
-            run_completer::<CalloutCompleter>(
-                completion_context,
-                params.text_document_position.position.line,
-                params.text_document_position.position.character,
-            )
-        } else {
-            None
-        }
+        run_completer::<CalloutCompleter>(
+            completion_context,
+            params.text_document_position.position.line,
+            params.text_document_position.position.character,
+        )
     })
 }
 


### PR DESCRIPTION
## Summary

Adds a new `callout_completions` boolean setting that allows users to disable callout completions. This addresses issue #226 where users want to disable the built-in callout completions to use their own snippet implementations (e.g., via LuaSnip).

The setting defaults to `true` to maintain backward compatibility. Users can set `callout_completions = false` in their `.moxide.toml` or `~/.config/moxide/settings.toml` to disable callout completions.

The setting check lives inside `CalloutCompleter::construct()`, consistent with how other settings (e.g. `heading_completions` in `link_completer.rs`) are handled — the orchestrator in `mod.rs` requires no special-casing.

### Demo

Default behavior (callout completions enabled) vs. `callout_completions = false`:

![Neovim testing video](https://app.devin.ai/api/presigned_proxy?token=eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJvcmdfaWQiOiJvcmctNzkyYWEwZTQ3OTJiNDgyZDllZDUwNmRhMjgzMzg4NzAiLCJ1c2VyX2lkIjoiZ29vZ2xlLW9hdXRoMnwxMTUwNzIwNTM3OTcxODI0NTA5NTAiLCJidWNrZXRfbmFtZSI6ImRldmluYXR0YWNobWVudHMiLCJidWNrZXRfa2V5IjoiYXR0YWNobWVudHNfcHJpdmF0ZS9vcmctNzkyYWEwZTQ3OTJiNDgyZDllZDUwNmRhMjgzMzg4NzAvMGZiZTJiMzItZDliMS00MzM5LWEwOWYtMmU3MzFiYWUwOWU4IiwiaWF0IjoxNzczMDc1OTE4LCJleHAiOjE3NzM2ODA3MTh9.tdmwb4XQGywN8lyuPsFqRk22frd9hq39zdJWm14UQ1o)

[View original video (rec-c9dadcae64f545b28ea77b51811e58b4-edited.mp4)](https://app.devin.ai/api/presigned_proxy?token=eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJvcmdfaWQiOiJvcmctNzkyYWEwZTQ3OTJiNDgyZDllZDUwNmRhMjgzMzg4NzAiLCJ1c2VyX2lkIjoiZ29vZ2xlLW9hdXRoMnwxMTUwNzIwNTM3OTcxODI0NTA5NTAiLCJidWNrZXRfbmFtZSI6ImRldmluYXR0YWNobWVudHMiLCJidWNrZXRfa2V5IjoiYXR0YWNobWVudHNfcHJpdmF0ZS9vcmctNzkyYWEwZTQ3OTJiNDgyZDllZDUwNmRhMjgzMzg4NzAvMmQ0OTdkNDUtNzdkNy00NjRiLWE1ZDUtZDE3OGRiOTFiNGVlIiwiaWF0IjoxNzczMDc1OTE4LCJleHAiOjE3NzM2ODA3MTh9.ttY2fkSxaIIfoC_M97TZL0TqIjVoP54TLGc3yXSvp2k)

## Review & Testing Checklist for Human

- [ ] Verify the setting works by adding `callout_completions = false` to `.moxide.toml` and confirming callout completions no longer appear when typing `> ` in a markdown file
- [ ] Confirm the default behavior (no config change) still provides callout completions as before

### Notes

Closes #226

Link to Devin session: https://app.devin.ai/sessions/be34e1bcad3941da9c351662703d2072
Requested by: Felix Zeller (@Feel-ix-343)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/feel-ix-343/markdown-oxide/pull/321" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
