### PR TITLE
Fix outdated source name in diagnostics

### DIFF
--- a/src/diagnostics.rs
+++ b/src/diagnostics.rs
@@ -66,7 +66,7 @@ pub fn diagnostics(
                 num if num > 1 => format!("Unresolved Reference used {} times", num),
                 _ => "Unresolved Reference".to_string(),
             },
-            source: Some("Obsidian LS".into()),
+            source: Some("markdown-oxide".into()),
             severity: Some(DiagnosticSeverity::INFORMATION),
             ..Default::default()
         })


### PR DESCRIPTION
## Summary
Updates the diagnostic source name from "Obsidian LS" to "markdown-oxide" to reflect the current project name. This was leftover naming from before the LSP was renamed.

Fixes #324

## Review & Testing Checklist for Human
- [ ] Verify diagnostics show "markdown-oxide" as the source in your editor (open a file with an unresolved reference)

### Notes
- Link to Devin run: https://app.devin.ai/sessions/019c2db4fc4849b48fd75a5d5cf291bc
- Requested by: Felix Zeller (@Feel-ix-343)