### PR TITLE
Fix vault indexing for hidden root directories and improve LSP client compatibility

### DIFF
--- a/src/vault/mod.rs
+++ b/src/vault/mod.rs
@@ -26,6 +26,10 @@ impl Vault {
         let md_file_paths = WalkDir::new(root_dir)
             .into_iter()
             .filter_entry(|e| {
+                // Allow the root directory itself even if it starts with '.'
+                if e.path() == root_dir {
+                    return true;
+                }
                 !e.file_name()
                     .to_str()
                     .map(|s| s.starts_with('.') || s == "logseq") // TODO: This is a temporary fix; a hidden config is better


### PR DESCRIPTION
1. Root directory filtering: The hidden file filter was also filtering the root directory itself if it started with . (e.g. .notes), resulting in 0 files indexed. Hidden subdirectories should still be filtered, but the root directory should always be allowed.
2. Missing workspace_folders support: The new Neovim LSP API may send workspace information via workspace_folders instead of root_uri. The server only checked root_uri, falling back to current_dir() which could be incorrect.
