### PR TITLE
fix: use `CompletionItemLabelDetails.description` for Aliases and unr…

### DIFF
--- a/src/completion/link_completer.rs
+++ b/src/completion/link_completer.rs
@@ -703,12 +703,12 @@ impl LinkCompletion<'_> {
                     infile_ref: _,
                     ..
                 } => Some(CompletionItemLabelDetails {
-                    detail: Some("Unresolved".into()),
-                    description: None,
+                    description: Some("Unresolved".into()),
+                    detail: None,
                 }),
                 Alias { filename, .. } => Some(CompletionItemLabelDetails {
-                    detail: Some(format!("Alias: {}.md", filename)),
-                    description: None,
+                    description: Some(format!("Alias: {}", filename)),
+                    detail: None,
                 }),
                 File { .. } => None,
                 Heading { .. } => None,


### PR DESCRIPTION
…esolved link completions

Follows the guidance of the official LSP spec by Microsoft in using `CompletionItemLabelDetails.description` over `CompletionItemLabelDetails.detail` for suffixes with spacing.

Fixes #332, where the problem is also explained in more detail.

---

I also removed the trailing `.md`, since imho those are redundant information (only markdown files can have aliases), but I can revert that if you prefer it that way.