### PR TITLE
fix log levels

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -54,7 +54,7 @@ struct TextDocumentItem {
 impl Backend {
     async fn update_vault(&self, params: TextDocumentItem) {
         self.client
-            .log_message(MessageType::WARNING, "Update Vault Started")
+            .log_message(MessageType::LOG, "Update Vault Started")
             .await;
 
         let Ok(path) = params.uri.to_file_path() else {
@@ -79,7 +79,7 @@ impl Backend {
         drop(guard);
 
         self.client
-            .log_message(MessageType::WARNING, "Update Vault Done")
+            .log_message(MessageType::LOG, "Update Vault Done")
             .await;
 
         match self.publish_diagnostics().await {
@@ -135,7 +135,7 @@ impl Backend {
         if elapsed.as_millis() > 10 {
             self.client
                 .log_message(
-                    MessageType::WARNING,
+                    MessageType::LOG,
                     format!("Vault Construction took {}ms", elapsed.as_millis()),
                 )
                 .await;
@@ -165,7 +165,7 @@ impl Backend {
         let timer = std::time::Instant::now();
 
         self.client
-            .log_message(MessageType::WARNING, "Diagnostics Started")
+            .log_message(MessageType::LOG, "Diagnostics Started")
             .await;
 
         let uris = self
@@ -198,14 +198,14 @@ impl Backend {
         }
 
         self.client
-            .log_message(MessageType::WARNING, "Diagnostics Done")
+            .log_message(MessageType::LOG, "Diagnostics Done")
             .await;
 
         let elapsed = timer.elapsed();
 
         self.client
             .log_message(
-                MessageType::WARNING,
+                MessageType::LOG,
                 format!("Diagnostics Done took {}ms", elapsed.as_millis()),
             )
             .await;
@@ -241,7 +241,7 @@ impl Backend {
                 .await;
         } else {
             self.client
-                .log_message(MessageType::ERROR, "VAULT Lock is good")
+                .log_message(MessageType::LOG, "VAULT Lock is good")
                 .await;
         }
 
@@ -283,7 +283,7 @@ impl Backend {
                 .await;
         } else {
             self.client
-                .log_message(MessageType::ERROR, "FILES Lock is good")
+                .log_message(MessageType::LOG, "FILES Lock is good")
                 .await;
         }
 
@@ -442,7 +442,7 @@ impl LanguageServer for Backend {
             .await
             .unwrap();
         self.client
-            .log_message(MessageType::WARNING, format!("Settings: {:?}", settings))
+            .log_message(MessageType::LOG, format!("Settings: {:?}", settings))
             .await;
 
         let Ok(root_path) = self.bind_vault(|vault| Ok(vault.root_dir().clone())).await else {
@@ -566,7 +566,7 @@ impl LanguageServer for Backend {
 
     async fn completion(&self, params: CompletionParams) -> Result<Option<CompletionResponse>> {
         self.client
-            .log_message(MessageType::WARNING, "Completions Started")
+            .log_message(MessageType::LOG, "Completions Started")
             .await;
 
         let timer = std::time::Instant::now();
@@ -588,7 +588,7 @@ impl LanguageServer for Backend {
 
         self.client
             .log_message(
-                MessageType::WARNING,
+                MessageType::LOG,
                 format!("Completions Done took {}ms", elapsed.as_millis()),
             )
             .await;
@@ -699,7 +699,7 @@ impl LanguageServer for Backend {
 
         self.client
             .log_message(
-                MessageType::WARNING,
+                MessageType::LOG,
                 format!("Semantic Tokens Done took {}ms", elapsed.as_millis()),
             )
             .await;
@@ -800,7 +800,7 @@ impl LanguageServer for Backend {
 
         self.client
             .log_message(
-                MessageType::INFO,
+                MessageType::LOG,
                 format!("Recalculating inlayHints for {params:?} {hints:?}"),
             )
             .await;


### PR DESCRIPTION
I was playing around with a fork of helix that adds popup notifications and discovered that `markdown-oxide` was sending several warnings and errors per-keystroke, since every time I typed something (and on file loads) I got a flood of popups in my editor.

Anyways, I figured I'd upstream a fix, which just changes some debug messages from `WARNING`/`ERROR` to `LOG` level, so they still exist for debugging but won't spam editors that display LSP messages.

Feel free to close if you have a reason to have the logs as they are; I don't mind building from my fork if needed.

Thanks for this tool, by the way! I've been using it daily for months :)