### PR TITLE
Support completion of tags with dashes, underscores

### DIFF
--- a/src/completion/tag_completer.rs
+++ b/src/completion/tag_completer.rs
@@ -41,7 +41,7 @@ impl<'a> Completer<'a> for TagCompleter<'a> {
         }
 
         static PARTIAL_TAG_REGEX: Lazy<Regex> =
-            Lazy::new(|| Regex::new(r"\#(?<text>[a-zA-Z0-9\/]*)").unwrap());
+            Lazy::new(|| Regex::new(r"\#(?<text>[a-zA-Z0-9/_-]*)").unwrap());
 
         let line_chars = context.vault.select_line(context.path, line as isize)?;
         let line_string = String::from_iter(line_chars);


### PR DESCRIPTION
Currently tags with dashes (e.g. `#some-tag`) are indexed, but only completed if the dashes and underscores aren't typed (e.g. type `#somet` or `#somta`, but not `#some-`).