### PR TITLE
docs: add Kakoune setup instructions

### DIFF
--- a/docs/Markdown Oxide Docs/README.md
+++ b/docs/Markdown Oxide Docs/README.md
@@ -26,6 +26,7 @@ Set up the PKM for your text editor...
 - [VSCode](#VSCode)
 - [Zed](#Zed)
 - [Helix](#Helix)
+- [Kakoune](#Kakoune)
 
 ## Neovim
 
@@ -331,3 +332,67 @@ For Helix, all you must do is install the language server's binary to your path.
     ```
 
 </details>
+
+## Kakoune
+
+Kakoune communicates with LSP servers through [kakoune-lsp](https://github.com/kakoune-lsp/kakoune-lsp) (binary name: `kak-lsp`). Install kakoune-lsp first if you haven't already.
+
+- Install the language server's binary to your path. The following installation methods are available:
+
+- <details>
+     <summary>Cargo Install (from source)</summary>
+
+    ```bash
+    cargo install --locked --git https://github.com/Feel-ix-343/markdown-oxide.git markdown-oxide
+    ```
+
+</details>
+
+- <details>
+    <summary>Cargo binstall (from hosted binary)</summary>
+
+    ```bash
+    cargo binstall --git 'https://github.com/feel-ix-343/markdown-oxide' markdown-oxide
+    ```
+
+</details>
+
+- Arch Linux: `pacman -S markdown-oxide`
+- Nix: `pkgs.markdown-oxide`
+- Alpine Linux: `apk add markdown-oxide`
+- openSUSE: `zypper install markdown-oxide`
+- Conda: `conda install conda-forge::markdown-oxide`
+
+- <details>
+     <summary>Winget (Windows)</summary>
+
+    ```bash
+    winget install FelixZeller.markdown-oxide
+    ```
+
+</details>
+
+- <details>
+     <summary>Homebrew (from package manager)</summary>
+
+    ```bash
+    brew install markdown-oxide
+    ```
+
+</details>
+
+- Configure kakoune-lsp to use markdown-oxide. Add the following to your `kakrc` (requires kakoune-lsp v17+):
+
+    ```kak
+    eval %sh{kak-lsp}
+    lsp-enable
+
+    hook -group lsp-filetype-markdown global BufSetOption filetype=markdown %{
+        set-option buffer lsp_servers %{
+            [markdown-oxide]
+            root_globs = [".obsidian", ".moxide.toml"]
+        }
+    }
+    ```
+
+    If you are using the older `kak-lsp.toml` configuration method, refer to the [kakoune-lsp wiki](https://github.com/kakoune-lsp/kakoune-lsp/wiki/How-to-install-servers) for setup instructions.

--- a/docs/Markdown Oxide Docs/Setup Instructions.md
+++ b/docs/Markdown Oxide Docs/Setup Instructions.md
@@ -18,6 +18,8 @@ Navigate to the setup for your editor using the table-of-contents to the right.
 
 ### ![[README#Helix]]
 
+### ![[README#Kakoune]]
+
 ## Configuration
 
 ![[Configuration#^configurationinfo]]


### PR DESCRIPTION
## Summary
- Add Kakoune section to the Quick Start guide in README.md
- Include kakoune-lsp (v17+) configuration example

## Motivation
- markdown-oxide works with any LSP-compatible editor, but no official guide exists for Kakoune
- kakoune-lsp's rc/servers.kak already has a commented-out entry for markdown-oxide

## Verified features

Environment: Arch Linux, Kakoune v2024.05.18, kakoune-lsp v19.0.1, markdown-oxide v0.25.9

Working:
- ✅ Wikilink / Tag / Footnote completions
- ✅ Go-to-definition, References (file, heading, tag, footnote, unresolved)
- ✅ Hover (preview, backlinks)
- ✅ Diagnostics (unresolved links)
- ✅ Document / Workspace symbols
- ✅ Code actions (create file from unresolved link)
- ✅ Rename (file, heading, tag)

Known limitations (kakoune-lsp side):
- ⚠️ Some completion triggers (`(`, `^`, `!`, `|`) don't fire due to
  kakoune-lsp's `lsp_completion_fragment_start` regex limitation
- ⚠️ Unresolved link completions may not appear (kakoune-lsp doesn't
  re-request when server returns `isIncomplete: true`)
- ⚠️ Daily notes commands unavailable (`window/showDocument` not yet
  supported by kakoune-lsp)
- ⚠️ Code lens not working (under investigation — may be related to
  URI parsing in markdown-oxide or kakoune-lsp interaction)

## Test plan
- [x] Tested with 30-item checklist covering completions, definitions,
      references, hover, diagnostics, symbols, code actions, rename,
      daily notes, code lens, inlay hints, and semantic tokens

🤖 Generated with [Claude Code](https://claude.com/claude-code)