### PR TITLE
feat: checkbox completions and toggle action

### DIFF
--- a/src/codeactions.rs
+++ b/src/codeactions.rs
@@ -20,22 +20,87 @@ pub fn code_actions(
     path: &Path,
     settings: &Settings,
 ) -> Option<Vec<CodeActionOrCommand>> {
+    let mut actions = Vec::new();
+
+    let get_checkbox_action = || -> Option<CodeActionOrCommand> {
+        let line_chars = vault.select_line(path, params.range.start.line as isize)?;
+        let line_str: String = line_chars.into_iter().collect();
+        let trimmed = line_str.trim_start();
+        
+        let space_idx = trimmed.find(' ')?;
+        let (bullet, rest) = trimmed.split_at(space_idx);
+        let rest_trimmed = rest.trim_start();
+        
+        let is_valid_bullet = bullet == "-" 
+            || bullet == "*" 
+            || bullet == "+" 
+            || (bullet.ends_with('.') && bullet[..bullet.len() - 1].chars().all(|c| c.is_ascii_digit()));
+
+        if !is_valid_bullet { return None; }
+
+        // This doesn't check the actual checkbox type, so - [!] will also be toggled
+        let has_bracket = rest_trimmed.starts_with('[') 
+            && rest_trimmed.len() >= 4 
+            && rest_trimmed.chars().nth(2) == Some(']') 
+            && rest_trimmed.chars().nth(3) == Some(' ');
+
+        if !has_bracket { return None; }
+
+        let is_unchecked = rest_trimmed.chars().nth(1) == Some(' ');
+        let prefix_bytes = line_str.len() - rest_trimmed.len();
+        let char_index = line_str[..prefix_bytes].chars().count();
+        
+        let new_char = if is_unchecked { "x" } else { " " };
+        let title = if is_unchecked { "Toggle checkbox (Check)" } else { "Toggle checkbox (Uncheck)" };
+
+        let uri = Url::from_file_path(path).ok()?;
+
+        Some(CodeActionOrCommand::CodeAction(CodeAction {
+            title: title.to_string(),
+            kind: Some(tower_lsp::lsp_types::CodeActionKind::REFACTOR),
+            edit: Some(WorkspaceEdit {
+                document_changes: Some(DocumentChanges::Operations(vec![
+                    DocumentChangeOperation::Edit(TextDocumentEdit {
+                        text_document: OptionalVersionedTextDocumentIdentifier {
+                            uri,
+                            version: None,
+                        },
+                        edits: vec![OneOf::Left(TextEdit {
+                            new_text: new_char.to_string(),
+                            range: Range {
+                                start: Position {
+                                    line: params.range.start.line,
+                                    character: (char_index + 1) as u32,
+                                },
+                                end: Position {
+                                    line: params.range.start.line,
+                                    character: (char_index + 2) as u32,
+                                },
+                            },
+                        })],
+                    }),
+                ])),
+                ..Default::default()
+            }),
+            ..Default::default()
+        }))
+    };
+
+    if let Some(action) = get_checkbox_action() {
+        actions.push(action);
+    }
+
     // Diagnostics
     // get all links for changed file
+    if let Some(unresolved_file_links) = path_unresolved_references(vault, path) {
+        let code_action_unresolved = unresolved_file_links.into_iter().filter(|(_, reference)| {
+            reference.data().range.start.line <= params.range.start.line
+                && reference.data().range.end.line >= params.range.end.line
+                && reference.data().range.start.character <= params.range.start.character
+                && reference.data().range.end.character >= params.range.end.character
+        });
 
-    let unresolved = path_unresolved_references(vault, path)?;
-
-    let unresolved_file_links = unresolved;
-
-    let code_action_unresolved = unresolved_file_links.into_iter().filter(|(_, reference)| {
-        reference.data().range.start.line <= params.range.start.line
-            && reference.data().range.end.line >= params.range.end.line
-            && reference.data().range.start.character <= params.range.start.character
-            && reference.data().range.end.character >= params.range.end.character
-    });
-
-    Some(
-        code_action_unresolved
+        let mut diagnostic_actions: Vec<CodeActionOrCommand> = code_action_unresolved
             .flat_map(|(_path, reference)| {
                 match reference {
                     Reference::WikiFileLink(_data) => {
@@ -144,6 +209,15 @@ pub fn code_actions(
                 }
 
             })
-            .collect(),
-    )
+            .collect();
+            
+        actions.append(&mut diagnostic_actions);
+    }
+
+    if actions.is_empty() {
+        None
+    } else {
+        Some(actions)
+    }
 }
+

--- a/src/completion/checkbox_completer.rs
+++ b/src/completion/checkbox_completer.rs
@@ -1,0 +1,144 @@
+use tower_lsp::lsp_types::{
+    CompletionItem, CompletionItemKind, CompletionItemLabelDetails, CompletionTextEdit,
+    InsertTextFormat, Position, Range, TextEdit,
+};
+
+use super::{Completable, Completer};
+
+pub struct CheckboxCompleter {
+    line: u32,
+    character: u32,
+    preceding_text: String,
+}
+
+impl<'a> Completer<'a> for CheckboxCompleter {
+    fn construct(context: super::Context<'a>, line: usize, character: usize) -> Option<Self>
+    where
+        Self: Sized + Completer<'a>,
+    {
+        if !context.settings.checkbox_completions {
+            return None;
+        }
+
+        let line_chars = context.vault.select_line(context.path, line as isize)?;
+        let text_up_to_cursor: String = line_chars.into_iter().take(character).collect();
+
+        let trimmed = text_up_to_cursor.trim_start();
+        
+        let space_idx = trimmed.find(' ')?;
+        let (bullet, rest) = trimmed.split_at(space_idx);
+        let rest_trimmed = rest.trim_start();
+        
+        let is_valid_bullet = bullet == "-" 
+            || bullet == "*" 
+            || bullet == "+" 
+            || (bullet.ends_with('.') && bullet[..bullet.len() - 1].chars().all(|c| c.is_ascii_digit()));
+
+        if !is_valid_bullet || !rest_trimmed.starts_with('[') {
+            return None;
+        }
+
+        // To avoid conflicting with normal links (e.g. `- [Link](...)`), 
+        // we strictly only trigger if the user typed `[`, `[ `, or `[` followed by a single character.
+        // It must not be longer than 2 characters (the bracket and one inner char)
+        if rest_trimmed.len() > 2 {
+            return None;
+        }
+
+        let prefix_len = text_up_to_cursor.len() - rest_trimmed.len();
+        let preceding_text = text_up_to_cursor[..prefix_len].to_string();
+
+        Some(Self {
+            preceding_text,
+            line: line as u32,
+            character: character as u32,
+        })
+    }
+
+    fn completions(&self) -> Vec<impl super::Completable<'a, Self>>
+    where
+        Self: Sized,
+    {
+        vec![
+            CheckboxCompletion::Unchecked,
+            CheckboxCompletion::Checked,
+            CheckboxCompletion::Important,
+            CheckboxCompletion::InProgress,
+            CheckboxCompletion::Scheduled,
+            CheckboxCompletion::Rescheduled,
+            CheckboxCompletion::Cancelled,
+            CheckboxCompletion::Question,
+            CheckboxCompletion::Star,
+            CheckboxCompletion::Info,
+            CheckboxCompletion::Quote,
+        ]
+    }
+
+    type FilterParams = &'static str;
+    fn completion_filter_text(&self, params: Self::FilterParams) -> String {
+        format!("{}[{}]", self.preceding_text, params)
+    }
+}
+
+enum CheckboxCompletion {
+    Unchecked,
+    Checked,
+    InProgress,
+    Rescheduled,
+    Cancelled,
+    Scheduled,
+    Important,
+    Question,
+    Star,
+    Info,
+    Quote,
+}
+
+impl Completable<'_, CheckboxCompleter> for CheckboxCompletion {
+    fn completions(&self, completer: &CheckboxCompleter) -> Option<CompletionItem> {
+        let (name, char_val, sort_idx) = match self {
+            Self::Unchecked => ("Unchecked", " ", "00"),
+            Self::Checked => ("Checked", "x", "01"),
+            Self::Important => ("Important", "!", "02"),
+            Self::InProgress => ("In Progress", "/", "03"),
+            Self::Scheduled => ("Scheduled", "<", "04"),
+            Self::Rescheduled => ("Rescheduled", ">", "05"),
+            Self::Cancelled => ("Cancelled", "-", "06"),
+            Self::Question => ("Question", "?", "07"),
+            Self::Star => ("Star", "*", "08"),
+            Self::Info => ("Info", "i", "09"),
+            Self::Quote => ("Quote", "\"", "10"),
+        };
+
+        let snippet = format!("{}[{}] ${{1}}", completer.preceding_text, char_val);
+        let filter_text = completer.completion_filter_text(char_val);
+
+        let completion_item = CompletionItem {
+            label: format!("[{}]", char_val),
+            label_details: Some(CompletionItemLabelDetails {
+                detail: Some(format!(" {}", name)),
+                description: None,
+            }),
+            insert_text_format: Some(InsertTextFormat::SNIPPET),
+            kind: Some(CompletionItemKind::SNIPPET),
+            text_edit: Some(CompletionTextEdit::Edit(TextEdit {
+                range: Range {
+                    start: Position {
+                        line: completer.line,
+                        character: 0,
+                    },
+                    end: Position {
+                        line: completer.line,
+                        character: completer.character,
+                    },
+                },
+                new_text: snippet,
+            })),
+            filter_text: Some(filter_text),
+            sort_text: Some(sort_idx.to_string()),
+            ..Default::default()
+        };
+
+        Some(completion_item)
+    }
+}

--- a/src/completion/mod.rs
+++ b/src/completion/mod.rs
@@ -5,6 +5,7 @@ use tower_lsp::lsp_types::{CompletionItem, CompletionList, CompletionParams, Com
 use crate::{config::Settings, vault::Vault};
 
 use self::callout_completer::CalloutCompleter;
+use self::checkbox_completer::CheckboxCompleter;
 use self::link_completer::WikiLinkCompleter;
 use self::{
     footnote_completer::FootnoteCompleter, link_completer::MarkdownLinkCompleter,
@@ -12,6 +13,7 @@ use self::{
 };
 
 mod callout_completer;
+mod checkbox_completer;
 mod footnote_completer;
 mod link_completer;
 mod matcher;
@@ -65,11 +67,18 @@ pub fn get_completions(
     };
 
     // I would refactor this if I could figure out generic closures
-    run_completer::<UnindexedBlockCompleter<MarkdownLinkCompleter>>(
+    run_completer::<CheckboxCompleter>(
         completion_context,
         params.text_document_position.position.line,
         params.text_document_position.position.character,
     )
+    .or_else(|| {
+        run_completer::<UnindexedBlockCompleter<MarkdownLinkCompleter>>(
+            completion_context,
+            params.text_document_position.position.line,
+            params.text_document_position.position.character,
+        )
+    })
     .or_else(|| {
         run_completer::<UnindexedBlockCompleter<WikiLinkCompleter>>(
             completion_context,

--- a/src/config.rs
+++ b/src/config.rs
@@ -32,6 +32,7 @@ pub struct Settings {
     pub excluded_folders: Vec<String>,
     pub heading_slug: bool,
     pub callout_completions: bool,
+    pub checkbox_completions: bool,
 }
 
 #[derive(Clone, Debug, Deserialize)]
@@ -103,6 +104,7 @@ impl Settings {
             .set_default("excluded_folders", Vec::<String>::new())?
             .set_default("heading_slug", false)?
             .set_default("callout_completions", true)?
+            .set_default("checkbox_completions", true)?
             .build()
             .map_err(|err| anyhow!("Build err: {err}"))?;
 


### PR DESCRIPTION
## Description

> Insert "we have Org mode at home" meme

I was missing two small features for check-boxes.

### Completions
For the various (no-markdown-standard/Obsidian) checkbox types:
<img width="438" height="315" alt="image" src="https://github.com/user-attachments/assets/15c591a4-6787-4411-b1dc-17e1cc471500" />
<img width="177" height="149" alt="image" src="https://github.com/user-attachments/assets/9500bcda-11b5-4731-a3fe-0be3a6c6e5db" />
(Rendered with markview.nvim)


### Toggle actions:
<img width="493" height="159" alt="image" src="https://github.com/user-attachments/assets/231fbd51-6fa2-4895-b7db-ce45e00d7216" />

### Disclaimer
I don't know how to program Rust. This was heavily assisted by AI. Seeing Devon is create pull requests left and right I'm guessing this is oke. Further testing this in daily use to test unexpected behavior. 

Let me know if this is something you like upstream otherwise I'll just keep it in my fork :)

