### PR TITLE
Performance - large files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@ Session.vim
 .aider*
 .env
 /.devenv
+.DS_Store

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -493,6 +493,7 @@ checksum = "65bc07b1a8bc7c85c5f2e110c476c7389b4554ba72af57d8445ea63a576b0876"
 dependencies = [
  "futures-channel",
  "futures-core",
+ "futures-executor",
  "futures-io",
  "futures-sink",
  "futures-task",
@@ -514,6 +515,17 @@ name = "futures-core"
 version = "0.3.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "05f29059c0c2090612e8d742178b0580d2dc940c837851ad723096f87af6663e"
+
+[[package]]
+name = "futures-executor"
+version = "0.3.31"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e28d1d997f585e54aebc3f97d39e72338912123a67330d723fdbb564d646c9f"
+dependencies = [
+ "futures-core",
+ "futures-task",
+ "futures-util",
+]
 
 [[package]]
 name = "futures-io"
@@ -917,6 +929,7 @@ dependencies = [
  "clap",
  "config",
  "do-notation",
+ "futures",
  "fuzzydate",
  "indexmap",
  "itertools",
@@ -932,6 +945,7 @@ dependencies = [
  "serde_yaml",
  "shellexpand",
  "tokio",
+ "tower",
  "tower-lsp",
  "urlencoding",
  "walkdir",
@@ -1659,6 +1673,7 @@ dependencies = [
  "pin-project-lite",
  "tower-layer",
  "tower-service",
+ "tracing",
 ]
 
 [[package]]
@@ -1711,6 +1726,7 @@ version = "0.1.41"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "784e0ac535deb450455cbfa28a6f0df145ea1bb7ae51b821cf5e7927fdcfbdd0"
 dependencies = [
+ "log",
  "pin-project-lite",
  "tracing-attributes",
  "tracing-core",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -31,6 +31,10 @@ walkdir = "2.4.0"
 do-notation = "0.1.3"
 urlencoding = "2.1.3"
 
+[dev-dependencies]
+futures = "0.3.31"
+tower = "0.4.13"
+
 [package.metadata.binstall]
 pkg-url = "{ repo }/releases/download/v{ version }/{ name }-v{ version }-{ target }{ archive-suffix }"
 

--- a/docs-dev/PERFORMANCE_LARGE_FILE.md
+++ b/docs-dev/PERFORMANCE_LARGE_FILE.md
@@ -67,20 +67,21 @@ If your platform builds `markdown-oxide.exe`, pass that path to `--binary` inste
 
 ## Run the built-in cargo perf tests
 
-These tests are `#[ignore]`d on purpose and should be run in `--release`.
+These perf regression tests are part of the normal test suite now. Running them in `--release`
+keeps the timing signal less noisy when you want to inspect them directly.
 
 `46ec5ca` does not contain them yet.
 
 Available from `61b341f` and later:
 
 ```bash
-cargo test --release test_inline_code_block_perf_regression -- --ignored
+cargo test --release test_inline_code_block_perf_regression
 ```
 
 Available from `6d0e8cf` and later:
 
 ```bash
-cargo test --release test_md_file_perf_regression -- --ignored
+cargo test --release test_md_file_perf_regression
 ```
 
 On `e86720e` and later, the external benchmark also prints the `Initialize timings:` log line, which is the fastest way to confirm where startup time is spent.

--- a/docs-dev/PERFORMANCE_LARGE_FILE.md
+++ b/docs-dev/PERFORMANCE_LARGE_FILE.md
@@ -1,0 +1,86 @@
+# Large-file benchmark
+
+## Summary
+
+This PR benchmarks only `FPF-Spec.md`, copied into a temporary **one-file vault**, so the numbers track **per-file parser cost** instead of cross-file indexing noise.
+
+| Commit | Rationale | `FPF-Spec.md` initialize |
+| --- | --- | --- |
+| `46ec5ca` | Baseline before this PR | `64.542s` |
+| `61b341f` | Reuse one `Rope` while parsing fenced and inline code blocks instead of rebuilding it for every backtick match | `11.851s` |
+| `6d0e8cf` | Reuse the same file `Rope` across the remaining markdown parsers (links, headings, tags, footnotes, indexed blocks, link-ref defs) | `0.921s` |
+| `e86720e` | Add `Initialize timings:` startup logs for future diagnosis; no material performance change expected | `0.850s` |
+
+## Reproduce the benchmark
+
+These commands assume **Bash + Python 3**. The script and downloaded `FPF-Spec.md` are copied into the system temp directory first so they survive `git checkout`.
+
+```bash
+cd /path/to/markdown-oxide
+
+SCRIPT_COPY="$(python3 - <<'PY'
+from pathlib import Path
+from tempfile import gettempdir
+print(Path(gettempdir()) / 'benchmark_large_file.py')
+PY
+)"
+
+BENCH_DIR="$(python3 - <<'PY'
+from pathlib import Path
+from tempfile import gettempdir
+print(Path(gettempdir()) / 'markdown-oxide-large-file')
+PY
+)"
+
+cp docs-dev/benchmark_large_file.py "$SCRIPT_COPY"
+python3 "$SCRIPT_COPY" fetch --output-dir "$BENCH_DIR"
+FPF_SPEC="$BENCH_DIR/FPF-Spec.md"
+```
+
+Benchmark the baseline and each PR commit:
+
+```bash
+git checkout 46ec5ca
+cargo build --release
+python3 "$SCRIPT_COPY" run --binary target/release/markdown-oxide --file "$FPF_SPEC"
+
+git checkout 61b341f
+cargo build --release
+python3 "$SCRIPT_COPY" run --binary target/release/markdown-oxide --file "$FPF_SPEC"
+
+git checkout 6d0e8cf
+cargo build --release
+python3 "$SCRIPT_COPY" run --binary target/release/markdown-oxide --file "$FPF_SPEC"
+
+git checkout e86720e
+cargo build --release
+python3 "$SCRIPT_COPY" run --binary target/release/markdown-oxide --file "$FPF_SPEC"
+```
+
+Return to the PR branch when done:
+
+```bash
+git switch perf/startup-vault-parsing
+```
+
+If your platform builds `markdown-oxide.exe`, pass that path to `--binary` instead.
+
+## Run the built-in cargo perf tests
+
+These tests are `#[ignore]`d on purpose and should be run in `--release`.
+
+`46ec5ca` does not contain them yet.
+
+Available from `61b341f` and later:
+
+```bash
+cargo test --release test_inline_code_block_perf_regression -- --ignored
+```
+
+Available from `6d0e8cf` and later:
+
+```bash
+cargo test --release test_md_file_perf_regression -- --ignored
+```
+
+On `e86720e` and later, the external benchmark also prints the `Initialize timings:` log line, which is the fastest way to confirm where startup time is spent.

--- a/docs-dev/benchmark_large_file.py
+++ b/docs-dev/benchmark_large_file.py
@@ -1,0 +1,219 @@
+#!/usr/bin/env python3
+
+from __future__ import annotations
+
+import argparse
+import json
+import shutil
+import subprocess
+import sys
+import tempfile
+import time
+import urllib.request
+from pathlib import Path
+
+DEFAULT_FPF_SPEC_URL = (
+    "https://raw.githubusercontent.com/ailev/FPF/main/FPF-Spec.md"
+)
+
+
+def fetch_fpf_spec(output_dir: Path, url: str) -> Path:
+    output_dir.mkdir(parents=True, exist_ok=True)
+    destination = output_dir / "FPF-Spec.md"
+
+    with urllib.request.urlopen(url) as response, destination.open("wb") as file:
+        shutil.copyfileobj(response, file)
+
+    return destination
+
+
+def send_message(process: subprocess.Popen[bytes], message: dict[str, object]) -> None:
+    body = json.dumps(message).encode("utf-8")
+    header = f"Content-Length: {len(body)}\r\n\r\n".encode("ascii")
+    assert process.stdin is not None
+    process.stdin.write(header + body)
+    process.stdin.flush()
+
+
+def read_message(process: subprocess.Popen[bytes]) -> dict[str, object]:
+    assert process.stdout is not None
+
+    headers: dict[str, str] = {}
+    while True:
+        line = process.stdout.readline()
+        if not line:
+            raise EOFError("unexpected EOF while reading LSP headers")
+        if line == b"\r\n":
+            break
+        key, value = line.decode("ascii").split(":", 1)
+        headers[key.strip().lower()] = value.strip()
+
+    length = int(headers["content-length"])
+    return json.loads(process.stdout.read(length))
+
+
+def benchmark_initialize(
+    binary: Path,
+    markdown_file: Path,
+    timeout_seconds: float,
+) -> tuple[float, list[str]]:
+    with tempfile.TemporaryDirectory(prefix="markdown-oxide-large-file-") as temp_dir:
+        vault_root = Path(temp_dir)
+        vault_file = vault_root / markdown_file.name
+        shutil.copy2(markdown_file, vault_file)
+
+        process = subprocess.Popen(
+            [str(binary)],
+            stdin=subprocess.PIPE,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+        )
+
+        try:
+            send_message(
+                process,
+                {
+                    "jsonrpc": "2.0",
+                    "id": 1,
+                    "method": "initialize",
+                    "params": {
+                        "processId": None,
+                        "rootUri": vault_root.resolve().as_uri(),
+                        "capabilities": {},
+                        "workspaceFolders": [
+                            {
+                                "uri": vault_root.resolve().as_uri(),
+                                "name": vault_root.name,
+                            }
+                        ],
+                        "clientInfo": {
+                            "name": "large-file-benchmark",
+                            "version": "1",
+                        },
+                        "initializationOptions": None,
+                    },
+                },
+            )
+
+            start = time.perf_counter()
+            logs: list[str] = []
+
+            while True:
+                if time.perf_counter() - start > timeout_seconds:
+                    raise TimeoutError(
+                        f"initialize did not finish within {timeout_seconds} seconds"
+                    )
+
+                message = read_message(process)
+                if message.get("method") == "window/logMessage":
+                    params = message.get("params", {})
+                    if isinstance(params, dict):
+                        log_message = params.get("message")
+                        if isinstance(log_message, str):
+                            logs.append(log_message)
+
+                if message.get("id") == 1:
+                    if "error" in message:
+                        raise RuntimeError(f"initialize failed: {message['error']}")
+                    elapsed = time.perf_counter() - start
+                    return elapsed, logs
+        finally:
+            try:
+                send_message(process, {"jsonrpc": "2.0", "method": "exit", "params": {}})
+            except Exception:
+                pass
+
+            process.terminate()
+            try:
+                process.wait(timeout=5)
+            except subprocess.TimeoutExpired:
+                process.kill()
+                process.wait(timeout=5)
+
+
+def fetch_command(args: argparse.Namespace) -> int:
+    destination = fetch_fpf_spec(args.output_dir, args.url)
+    print(destination)
+    return 0
+
+
+def run_command(args: argparse.Namespace) -> int:
+    binary = args.binary.resolve()
+    markdown_file = args.file.resolve()
+
+    if not binary.exists():
+        raise FileNotFoundError(f"binary does not exist: {binary}")
+    if not markdown_file.exists():
+        raise FileNotFoundError(f"markdown file does not exist: {markdown_file}")
+
+    elapsed, logs = benchmark_initialize(binary, markdown_file, args.timeout_seconds)
+
+    print(f"binary={binary}")
+    print(f"markdown_file={markdown_file}")
+    print(f"file_size_bytes={markdown_file.stat().st_size}")
+    print(f"initialize_seconds={elapsed:.3f}")
+
+    for log in logs:
+        print(log)
+
+    return 0
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        description="Fetch FPF-Spec.md and benchmark markdown-oxide on a one-file vault."
+    )
+    subparsers = parser.add_subparsers(dest="command", required=True)
+
+    fetch_parser = subparsers.add_parser(
+        "fetch",
+        help="Download FPF-Spec.md into a stable directory outside the git checkout.",
+    )
+    fetch_parser.add_argument(
+        "--output-dir",
+        type=Path,
+        required=True,
+        help="Directory that will receive FPF-Spec.md.",
+    )
+    fetch_parser.add_argument(
+        "--url",
+        default=DEFAULT_FPF_SPEC_URL,
+        help=f"Source URL (default: {DEFAULT_FPF_SPEC_URL}).",
+    )
+    fetch_parser.set_defaults(func=fetch_command)
+
+    run_parser = subparsers.add_parser(
+        "run",
+        help="Benchmark raw LSP initialize time against a one-file vault.",
+    )
+    run_parser.add_argument(
+        "--binary",
+        type=Path,
+        required=True,
+        help="Path to the markdown-oxide release binary.",
+    )
+    run_parser.add_argument(
+        "--file",
+        type=Path,
+        required=True,
+        help="Path to FPF-Spec.md (or another large markdown file).",
+    )
+    run_parser.add_argument(
+        "--timeout-seconds",
+        type=float,
+        default=180.0,
+        help="Fail if initialize takes longer than this many seconds.",
+    )
+    run_parser.set_defaults(func=run_command)
+
+    return parser
+
+
+def main() -> int:
+    parser = build_parser()
+    args = parser.parse_args()
+    return args.func(args)
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/src/main.rs
+++ b/src/main.rs
@@ -51,6 +51,44 @@ struct TextDocumentItem {
     text: String,
 }
 
+fn vault_debug_summary(vault: &Vault) -> String {
+    let markdown_files = vault.md_files.len();
+    let references = vault
+        .md_files
+        .values()
+        .map(|file| file.references.len())
+        .sum::<usize>();
+    let headings = vault
+        .md_files
+        .values()
+        .map(|file| file.headings.len())
+        .sum::<usize>();
+    let tags = vault
+        .md_files
+        .values()
+        .map(|file| file.tags.len())
+        .sum::<usize>();
+    let footnotes = vault
+        .md_files
+        .values()
+        .map(|file| file.footnotes.len())
+        .sum::<usize>();
+    let indexed_blocks = vault
+        .md_files
+        .values()
+        .map(|file| file.indexed_blocks.len())
+        .sum::<usize>();
+    let link_ref_defs = vault
+        .md_files
+        .values()
+        .map(|file| file.link_reference_definitions.len())
+        .sum::<usize>();
+
+    format!(
+        "markdown_files={markdown_files}, references={references}, headings={headings}, tags={tags}, footnotes={footnotes}, indexed_blocks={indexed_blocks}, link_ref_defs={link_ref_defs}"
+    )
+}
+
 impl Backend {
     async fn update_vault(&self, params: TextDocumentItem) {
         self.client
@@ -112,21 +150,26 @@ impl Backend {
             return;
         };
 
-        {
-            let _ = self
-                .bind_vault_mut(|vault| {
-                    let Ok(new_vault) = Vault::construct_vault(&settings, vault.root_dir()) else {
-                        return Err(Error::new(ErrorCode::ServerError(0)));
-                    };
+        let build_timer = std::time::Instant::now();
 
-                    *vault = new_vault;
+        let Ok(vault_summary) = self
+            .bind_vault_mut(|vault| {
+                let Ok(new_vault) = Vault::construct_vault(&settings, vault.root_dir()) else {
+                    return Err(Error::new(ErrorCode::ServerError(0)));
+                };
 
-                    Ok(())
-                })
-                .await;
-        }
+                let summary = vault_debug_summary(&new_vault);
+                *vault = new_vault;
+
+                Ok(summary)
+            })
+            .await
+        else {
+            return;
+        };
 
         let elapsed = timer.elapsed();
+        let build_elapsed = build_timer.elapsed();
 
         progress
             .finish_with_message(format!("Finished in {}ms", elapsed.as_millis()))
@@ -136,7 +179,12 @@ impl Backend {
             self.client
                 .log_message(
                     MessageType::LOG,
-                    format!("Vault Construction took {}ms", elapsed.as_millis()),
+                    format!(
+                        "Vault Construction took {}ms (construct_vault={}ms, {})",
+                        elapsed.as_millis(),
+                        build_elapsed.as_millis(),
+                        vault_summary
+                    ),
                 )
                 .await;
         }
@@ -295,6 +343,7 @@ impl Backend {
 #[tower_lsp::async_trait]
 impl LanguageServer for Backend {
     async fn initialize(&self, i: InitializeParams) -> Result<InitializeResult> {
+        let initialize_timer = std::time::Instant::now();
         self.client
             .log_message(
                 MessageType::LOG,
@@ -340,6 +389,7 @@ impl LanguageServer for Backend {
             .log_message(MessageType::LOG, format!("Using root_dir: {:?}", root_dir))
             .await;
 
+        let settings_timer = std::time::Instant::now();
         let read_settings = match Settings::new(&root_dir, &i.capabilities) {
             Ok(settings) => settings,
             Err(e) => {
@@ -352,15 +402,32 @@ impl LanguageServer for Backend {
                 return Err(Error::new(ErrorCode::ServerError(1)));
             }
         };
+        let settings_elapsed = settings_timer.elapsed();
 
+        let vault_timer = std::time::Instant::now();
         let Ok(vault) = Vault::construct_vault(&read_settings, &root_dir) else {
             return Err(Error::new(ErrorCode::ServerError(0)));
         };
+        let vault_elapsed = vault_timer.elapsed();
+        let vault_summary = vault_debug_summary(&vault);
         let mut value = self.vault.write().await;
         *value = Some(vault);
 
         let mut settings = self.settings.write().await;
         *settings = Some(read_settings);
+
+        self.client
+            .log_message(
+                MessageType::LOG,
+                format!(
+                    "Initialize timings: settings={}ms, construct_vault={}ms, total={}ms, {}",
+                    settings_elapsed.as_millis(),
+                    vault_elapsed.as_millis(),
+                    initialize_timer.elapsed().as_millis(),
+                    vault_summary
+                ),
+            )
+            .await;
 
         let file_op_reg = FileOperationRegistrationOptions {
             filters: std::iter::once(FileOperationFilter {

--- a/src/main.rs
+++ b/src/main.rs
@@ -138,21 +138,33 @@ impl Backend {
     }
 
     async fn reconstruct_vault(&self) {
+        let timer = std::time::Instant::now();
+
+        let settings = match self.bind_settings(|settings| Ok(settings.clone())).await {
+            Ok(settings) => settings,
+            Err(err) => {
+                self.client
+                    .log_message(
+                        MessageType::ERROR,
+                        format!(
+                            "Failed to read settings during vault reconstruction {:?}",
+                            err
+                        ),
+                    )
+                    .await;
+                return;
+            }
+        };
+
         let progress = self
             .client
             .progress(ProgressToken::Number(1), "Constructing Vault")
             .begin()
             .await;
 
-        let timer = std::time::Instant::now();
-
-        let Ok(settings) = self.bind_settings(|settings| Ok(settings.clone())).await else {
-            return;
-        };
-
         let build_timer = std::time::Instant::now();
 
-        let Ok(vault_summary) = self
+        let vault_summary = match self
             .bind_vault_mut(|vault| {
                 let Ok(new_vault) = Vault::construct_vault(&settings, vault.root_dir()) else {
                     return Err(Error::new(ErrorCode::ServerError(0)));
@@ -164,8 +176,20 @@ impl Backend {
                 Ok(summary)
             })
             .await
-        else {
-            return;
+        {
+            Ok(summary) => summary,
+            Err(err) => {
+                progress
+                    .finish_with_message("Vault construction failed")
+                    .await;
+                self.client
+                    .log_message(
+                        MessageType::ERROR,
+                        format!("Failed reconstructing vault {:?}", err),
+                    )
+                    .await;
+                return;
+            }
         };
 
         let elapsed = timer.elapsed();
@@ -1048,5 +1072,194 @@ async fn main() {
             });
             Server::new(stdin, stdout, socket).serve(service).await;
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::collections::HashSet;
+    use std::fs;
+    use std::path::{Path, PathBuf};
+    use std::sync::Arc;
+    use std::time::{Duration, SystemTime, UNIX_EPOCH};
+
+    use futures::StreamExt;
+    use serde_json::{json, Value};
+    use tower::{Service, ServiceExt};
+    use tower_lsp::jsonrpc::Request;
+    use tower_lsp::lsp_types::Url;
+    use tower_lsp::{ClientSocket, LspService};
+
+    use super::Backend;
+
+    struct TestDir(PathBuf);
+
+    impl TestDir {
+        fn new(prefix: &str) -> Self {
+            let unique = SystemTime::now()
+                .duration_since(UNIX_EPOCH)
+                .expect("system clock should be after unix epoch")
+                .as_nanos();
+            let path = std::env::temp_dir().join(format!(
+                "markdown-oxide-{prefix}-{}-{unique}",
+                std::process::id()
+            ));
+            fs::create_dir_all(&path).expect("test temp dir should be created");
+            Self(path)
+        }
+
+        fn path(&self) -> &Path {
+            &self.0
+        }
+    }
+
+    impl Drop for TestDir {
+        fn drop(&mut self) {
+            let _ = fs::remove_dir_all(&self.0);
+        }
+    }
+
+    async fn collect_notifications_while<T>(
+        socket: &mut ClientSocket,
+        future: impl std::future::Future<Output = T>,
+    ) -> (T, Vec<Request>) {
+        tokio::pin!(future);
+        let mut notifications = Vec::new();
+
+        loop {
+            tokio::select! {
+                result = &mut future => {
+                    loop {
+                        match tokio::time::timeout(Duration::from_millis(50), socket.next()).await {
+                            Ok(Some(notification)) => notifications.push(notification),
+                            Ok(None) | Err(_) => return (result, notifications),
+                        }
+                    }
+                }
+                notification = socket.next() => match notification {
+                    Some(notification) => notifications.push(notification),
+                    None => unreachable!("client socket should stay open during tests"),
+                },
+            }
+        }
+    }
+
+    async fn initialized_backend(root_dir: &Path) -> (LspService<Backend>, ClientSocket) {
+        let (mut service, socket) = LspService::new(|client| Backend {
+            client,
+            vault: Arc::new(tokio::sync::RwLock::new(None)),
+            opened_files: Arc::new(tokio::sync::RwLock::new(HashSet::new())),
+            settings: Arc::new(tokio::sync::RwLock::new(None)),
+        });
+        let mut socket = socket;
+
+        let root_uri =
+            Url::from_directory_path(root_dir).expect("test root dir should convert to file URL");
+        let (response, _) = collect_notifications_while(
+            &mut socket,
+            tokio::time::timeout(Duration::from_secs(5), async {
+                service
+                    .ready()
+                    .await
+                    .expect("service should be ready for initialize")
+                    .call(
+                        Request::build("initialize")
+                            .id(1)
+                            .params(json!({
+                                "processId": null,
+                                "rootUri": root_uri,
+                                "capabilities": {},
+                            }))
+                            .finish(),
+                    )
+                    .await
+                    .expect("initialize request should succeed")
+            }),
+        )
+        .await;
+        let response = response.expect("initialize request should not time out");
+
+        assert!(
+            matches!(response, Some(ref response) if response.error().is_none()),
+            "initialize should return a success response: {response:?}"
+        );
+
+        (service, socket)
+    }
+
+    fn progress_kind(request: &Request) -> Option<&str> {
+        request
+            .params()
+            .and_then(|params| params.get("value"))
+            .and_then(|value| value.get("kind"))
+            .and_then(Value::as_str)
+    }
+
+    fn progress_end_message(request: &Request) -> Option<&str> {
+        request
+            .params()
+            .and_then(|params| params.get("value"))
+            .and_then(|value| value.get("message"))
+            .and_then(Value::as_str)
+    }
+
+    #[tokio::test(flavor = "current_thread")]
+    async fn reconstruct_vault_does_not_start_progress_without_settings() {
+        let root_dir = TestDir::new("reconstruct-no-settings");
+        let (service, mut socket) = initialized_backend(root_dir.path()).await;
+
+        *service.inner().settings.write().await = None;
+
+        let (result, notifications) = collect_notifications_while(
+            &mut socket,
+            tokio::time::timeout(Duration::from_secs(5), service.inner().reconstruct_vault()),
+        )
+        .await;
+        result.expect("reconstruct_vault should not time out");
+        let progress_notifications = notifications
+            .iter()
+            .filter(|notification| notification.method() == "$/progress")
+            .collect::<Vec<_>>();
+
+        assert!(
+            progress_notifications.is_empty(),
+            "expected no progress notifications when settings are missing, got {progress_notifications:?}"
+        );
+    }
+
+    #[tokio::test(flavor = "current_thread")]
+    async fn reconstruct_vault_finishes_progress_when_vault_is_unavailable() {
+        let root_dir = TestDir::new("reconstruct-failure");
+        let (service, mut socket) = initialized_backend(root_dir.path()).await;
+
+        *service.inner().vault.write().await = None;
+
+        let (result, notifications) = collect_notifications_while(
+            &mut socket,
+            tokio::time::timeout(Duration::from_secs(5), service.inner().reconstruct_vault()),
+        )
+        .await;
+        result.expect("reconstruct_vault should not time out");
+        let progress_notifications = notifications
+            .iter()
+            .filter(|notification| notification.method() == "$/progress")
+            .collect::<Vec<_>>();
+        let progress_kinds = progress_notifications
+            .iter()
+            .filter_map(|notification| progress_kind(notification))
+            .collect::<Vec<_>>();
+
+        assert_eq!(
+            progress_kinds,
+            vec!["begin", "end"],
+            "expected reconstruct_vault to close progress on rebuild failure, got {progress_notifications:?}"
+        );
+        assert_eq!(
+            progress_notifications
+                .iter()
+                .find(|notification| progress_kind(notification) == Some("end"))
+                .and_then(|notification| progress_end_message(notification)),
+            Some("Vault construction failed")
+        );
     }
 }

--- a/src/vault/mod.rs
+++ b/src/vault/mod.rs
@@ -661,7 +661,8 @@ pub struct MDFile {
 
 impl MDFile {
     fn new(context: &Settings, text: &str, path: PathBuf) -> MDFile {
-        let code_blocks = MDCodeBlock::new(text).collect_vec();
+        let rope = Rope::from_str(text);
+        let code_blocks = MDCodeBlock::collect_with_rope(text, &rope);
         let file_name = path
             .file_stem()
             .expect("file should have file stem")

--- a/src/vault/mod.rs
+++ b/src/vault/mod.rs
@@ -6,7 +6,7 @@ use std::{
     collections::{HashMap, HashSet},
     hash::Hash,
     iter,
-    ops::{Deref, DerefMut, Not, Range},
+    ops::{Deref, DerefMut, Range},
     path::{Path, PathBuf, MAIN_SEPARATOR},
     time::SystemTime,
 };
@@ -672,27 +672,37 @@ impl MDFile {
             Settings {
                 references_in_codeblocks: false,
                 ..
-            } => Reference::new(text, file_name)
+            } => Reference::collect_with_rope(text, file_name, &rope)
+                .into_iter()
                 .filter(|it| !code_blocks.iter().any(|codeblock| codeblock.includes(it)))
                 .collect_vec(),
-            _ => Reference::new(text, file_name).collect_vec(),
+            _ => Reference::collect_with_rope(text, file_name, &rope),
         };
-        let headings = MDHeading::new(text)
-            .filter(|it| !code_blocks.iter().any(|codeblock| codeblock.includes(it)));
-        let footnotes = MDFootnote::new(text)
-            .filter(|it| !code_blocks.iter().any(|codeblock| codeblock.includes(it)));
-        let link_refs = MDLinkReferenceDefinition::new(text)
-            .filter(|it| !code_blocks.iter().any(|codeblock| codeblock.includes(it)));
-        let indexed_blocks = MDIndexedBlock::new(text)
-            .filter(|it| !code_blocks.iter().any(|codeblock| codeblock.includes(it)));
+        let headings = MDHeading::collect_with_rope(text, &rope)
+            .into_iter()
+            .filter(|it| !code_blocks.iter().any(|codeblock| codeblock.includes(it)))
+            .collect();
+        let footnotes = MDFootnote::collect_with_rope(text, &rope)
+            .into_iter()
+            .filter(|it| !code_blocks.iter().any(|codeblock| codeblock.includes(it)))
+            .collect();
+        let link_refs = MDLinkReferenceDefinition::collect_with_rope(text, &rope)
+            .into_iter()
+            .filter(|it| !code_blocks.iter().any(|codeblock| codeblock.includes(it)))
+            .collect();
+        let indexed_blocks = MDIndexedBlock::collect_with_rope(text, &rope)
+            .into_iter()
+            .filter(|it| !code_blocks.iter().any(|codeblock| codeblock.includes(it)))
+            .collect();
         let tags = match context {
             Settings {
                 tags_in_codeblocks: false,
                 ..
-            } => MDTag::new(text)
+            } => MDTag::collect_with_rope(text, &rope)
+                .into_iter()
                 .filter(|it| !code_blocks.iter().any(|codeblock| codeblock.includes(it)))
                 .collect_vec(),
-            _ => MDTag::new(text).collect_vec(),
+            _ => MDTag::collect_with_rope(text, &rope),
         };
         let metadata = MDMetadata::new(text);
 
@@ -721,12 +731,12 @@ impl MDFile {
 
         MDFile {
             references: all_links,
-            headings: headings.collect(),
-            indexed_blocks: indexed_blocks.collect(),
+            headings,
+            indexed_blocks,
             tags: all_tags,
-            footnotes: footnotes.collect(),
+            footnotes,
             path,
-            link_reference_definitions: link_refs.collect(),
+            link_reference_definitions: link_refs,
             metadata,
             codeblocks: code_blocks,
         }
@@ -856,6 +866,11 @@ impl Reference {
     }
 
     pub fn new<'a>(text: &'a str, file_name: &'a str) -> impl Iterator<Item = Reference> + 'a {
+        let rope = Rope::from_str(text);
+        Self::collect_with_rope(text, file_name, &rope).into_iter()
+    }
+
+    fn collect_with_rope(text: &str, file_name: &str, rope: &Rope) -> Vec<Reference> {
         static WIKI_LINK_RE: Lazy<Regex> = Lazy::new(|| {
             Regex::new(r"\[\[(?<filepath>[^\[\]\|\#]+?)?(?<ending>\.md)?(\#(?<infileref>[^\[\]\|]+))?(\|(?<display>[^\[\]\|]+))?\]\]")
 
@@ -872,8 +887,9 @@ impl Reference {
             })
             .flat_map(RegexTuple::new)
             .flat_map(|regextuple| {
-                generic_link_constructor::<WikiReferenceConstructor>(text, file_name, regextuple)
-            });
+                generic_link_constructor::<WikiReferenceConstructor>(file_name, rope, regextuple)
+            })
+            .collect_vec();
 
         static MD_LINK_RE: Lazy<Regex> = Lazy::new(|| {
             Regex::new(r"\[(?<display>[^\[\]]*?)\]\(<?(?<filepath>(\.?\/)?[^\[\]\|\#<>]+?)?(?<ending>\.md)?(\#(?<infileref>[^\[\]\|<>]+?))?>?\)")
@@ -890,16 +906,20 @@ impl Reference {
             })
             .flat_map(RegexTuple::new)
             .flat_map(|regextuple| {
-                generic_link_constructor::<MDReferenceConstructor>(text, file_name, regextuple)
-            });
-
-        let tags = MDTag::new(text).map(|tag| {
-            Tag(ReferenceData {
-                display_text: None,
-                range: tag.range,
-                reference_text: format!("#{}", tag.tag_ref),
+                generic_link_constructor::<MDReferenceConstructor>(file_name, rope, regextuple)
             })
-        });
+            .collect_vec();
+
+        let tags = MDTag::collect_with_rope(text, rope)
+            .into_iter()
+            .map(|tag| {
+                Tag(ReferenceData {
+                    display_text: None,
+                    range: tag.range,
+                    reference_text: format!("#{}", tag.tag_ref),
+                })
+            })
+            .collect_vec();
 
         static FOOTNOTE_LINK_RE: Lazy<Regex> = Lazy::new(|| {
             Regex::new(r"(?<start>\[?)(?<full>\[(?<index>\^[^\[\] ]+)\])(?<end>:?)").unwrap()
@@ -919,23 +939,19 @@ impl Reference {
             .map(|(outer, index)| {
                 Footnote(ReferenceData {
                     reference_text: index.as_str().into(),
-                    range: MyRange::from_range(&Rope::from_str(text), outer.range()),
+                    range: MyRange::from_range(rope, outer.range()),
                     display_text: None,
                 })
-            });
+            })
+            .collect_vec();
 
-        let link_ref_references: Vec<Reference> = if MDLinkReferenceDefinition::new(text)
-            .collect_vec()
-            .is_empty()
-            .not()
-        {
+        let link_ref_references: Vec<Reference> = if MDLinkReferenceDefinition::has_any(text) {
             static LINK_REF_RE: Lazy<Regex> = Lazy::new(|| {
                 Regex::new(r"([^\[]|^)(?<full>\[(?<index>[^\^][^\[\] ]+)\])([^\]\(\:]|$)").unwrap()
             });
 
-            let link_ref_references: Vec<Reference> = LINK_REF_RE
+            LINK_REF_RE
                 .captures_iter(text)
-                .par_bridge()
                 .flat_map(
                     |capture| match (capture.name("full"), capture.name("index")) {
                         (Some(full), Some(index)) => Some((full, index)),
@@ -945,13 +961,11 @@ impl Reference {
                 .map(|(outer, index)| {
                     LinkRef(ReferenceData {
                         reference_text: index.as_str().into(),
-                        range: MyRange::from_range(&Rope::from_str(text), outer.range()),
+                        range: MyRange::from_range(rope, outer.range()),
                         display_text: None,
                     })
                 })
-                .collect::<Vec<_>>();
-
-            link_ref_references
+                .collect()
         } else {
             vec![]
         };
@@ -962,6 +976,7 @@ impl Reference {
             .chain(tags)
             .chain(footnote_references)
             .chain(link_ref_references)
+            .collect()
     }
 
     pub fn references(
@@ -1146,8 +1161,8 @@ fn has_non_markdown_extension(path: &str) -> bool {
 }
 
 fn generic_link_constructor<T: ParseableReferenceConstructor>(
-    text: &str,
     file_name: &str,
+    rope: &Rope,
     RegexTuple {
         range,
         file_path,
@@ -1182,14 +1197,14 @@ fn generic_link_constructor<T: ParseableReferenceConstructor>(
         // Pure file reference as there is no infileref such as #... for headings or #^... for indexed blocks
         (full, filepath, None, display) => Some(T::new_file_link(ReferenceData {
             reference_text: filepath.into(),
-            range: MyRange::from_range(&Rope::from_str(text), full.range()),
+            range: MyRange::from_range(rope, full.range()),
             display_text: display.map(|d| d.as_str().into()),
         })),
         (full, filepath, Some(infile), display) if infile.as_str().get(0..1) == Some("^") => {
             Some(T::new_indexed_block_link(
                 ReferenceData {
                     reference_text: format!("{}#{}", filepath, infile.as_str()),
-                    range: MyRange::from_range(&Rope::from_str(text), full.range()),
+                    range: MyRange::from_range(rope, full.range()),
                     display_text: display.map(|d| d.as_str().into()),
                 },
                 filepath,
@@ -1199,7 +1214,7 @@ fn generic_link_constructor<T: ParseableReferenceConstructor>(
         (full, filepath, Some(infile), display) => Some(T::new_heading(
             ReferenceData {
                 reference_text: format!("{}#{}", filepath, infile.as_str()),
-                range: MyRange::from_range(&Rope::from_str(text), full.range()),
+                range: MyRange::from_range(rope, full.range()),
                 display_text: display.map(|d| d.as_str().into()),
             },
             filepath,
@@ -1283,7 +1298,13 @@ impl From<tower_lsp::lsp_types::Range> for MyRange {
 }
 
 impl MDHeading {
+    #[cfg(test)]
     fn new(text: &str) -> impl Iterator<Item = MDHeading> + '_ {
+        let rope = Rope::from_str(text);
+        Self::collect_with_rope(text, &rope).into_iter()
+    }
+
+    fn collect_with_rope(text: &str, rope: &Rope) -> Vec<MDHeading> {
         static HEADING_RE: Lazy<Regex> =
             Lazy::new(|| Regex::new(r"(?<starter>#+) (?<heading_text>.+)").unwrap());
 
@@ -1306,9 +1327,10 @@ impl MDHeading {
             .filter(move |(full_heading, _, _)| full_heading.start() >= frontmatter_end)
             .map(|(full_heading, heading_match, starter)| MDHeading {
                 heading_text: heading_match.as_str().trim_end().into(),
-                range: MyRange::from_range(&Rope::from_str(text), full_heading.range()),
+                range: MyRange::from_range(rope, full_heading.range()),
                 level: HeadingLevel(starter.as_str().len()),
-            });
+            })
+            .collect();
 
         headings
     }
@@ -1328,7 +1350,13 @@ impl Hash for MDIndexedBlock {
 }
 
 impl MDIndexedBlock {
+    #[cfg(test)]
     fn new(text: &str) -> impl Iterator<Item = MDIndexedBlock> + '_ {
+        let rope = Rope::from_str(text);
+        Self::collect_with_rope(text, &rope).into_iter()
+    }
+
+    fn collect_with_rope(text: &str, rope: &Rope) -> Vec<MDIndexedBlock> {
         static INDEXED_BLOCK_RE: Lazy<Regex> =
             Lazy::new(|| Regex::new(r".+ (\^(?<index>\w+))").unwrap());
 
@@ -1340,8 +1368,9 @@ impl MDIndexedBlock {
             })
             .map(|(full, index)| MDIndexedBlock {
                 index: index.as_str().into(),
-                range: MyRange::from_range(&Rope::from_str(text), full.range()),
-            });
+                range: MyRange::from_range(rope, full.range()),
+            })
+            .collect();
 
         indexed_blocks
     } // Make this better identify the full blocks
@@ -1362,7 +1391,13 @@ impl Hash for MDFootnote {
 }
 
 impl MDFootnote {
+    #[cfg(test)]
     fn new(text: &str) -> impl Iterator<Item = MDFootnote> + '_ {
+        let rope = Rope::from_str(text);
+        Self::collect_with_rope(text, &rope).into_iter()
+    }
+
+    fn collect_with_rope(text: &str, rope: &Rope) -> Vec<MDFootnote> {
         // static FOOTNOTE_RE: Lazy<Regex> = Lazy::new(|| Regex::new(r".+ (\^(?<index>\w+))").unwrap());
         static FOOTNOTE_RE: Lazy<Regex> =
             Lazy::new(|| Regex::new(r"\[(?<index>\^[^ \[\]]+)\]\:(?<text>.+)").unwrap());
@@ -1378,8 +1413,9 @@ impl MDFootnote {
             .map(|(full, index, footnote_text)| MDFootnote {
                 footnote_text: footnote_text.as_str().trim_start().into(),
                 index: index.as_str().into(),
-                range: MyRange::from_range(&Rope::from_str(text), full.range()),
-            });
+                range: MyRange::from_range(rope, full.range()),
+            })
+            .collect();
 
         footnotes
     }
@@ -1398,7 +1434,13 @@ impl Hash for MDTag {
 }
 
 impl MDTag {
+    #[cfg(test)]
     fn new(text: &str) -> impl Iterator<Item = MDTag> + '_ {
+        let rope = Rope::from_str(text);
+        Self::collect_with_rope(text, &rope).into_iter()
+    }
+
+    fn collect_with_rope(text: &str, rope: &Rope) -> Vec<MDTag> {
         static TAG_RE: Lazy<Regex> = Lazy::new(|| {
             Regex::new(r#"(?x)
                 # 1. Boundary assertion: The tag must be preceded by the start of the string, a newline, or whitespace.
@@ -1432,8 +1474,9 @@ impl MDTag {
             .filter(|(_, index)| index.as_str().chars().any(|c| c.is_alphabetic()))
             .map(|(full, index)| MDTag {
                 tag_ref: index.as_str().into(),
-                range: MyRange::from_range(&Rope::from_str(text), full.range()),
-            });
+                range: MyRange::from_range(rope, full.range()),
+            })
+            .collect();
 
         tagged_blocks
     }
@@ -1503,7 +1546,19 @@ pub struct MDLinkReferenceDefinition {
 }
 
 impl MDLinkReferenceDefinition {
+    #[cfg(test)]
     fn new(text: &str) -> impl Iterator<Item = MDLinkReferenceDefinition> + '_ {
+        let rope = Rope::from_str(text);
+        Self::collect_with_rope(text, &rope).into_iter()
+    }
+
+    fn has_any(text: &str) -> bool {
+        static REGEX: Lazy<Regex> =
+            Lazy::new(|| Regex::new(r"\[(?<index>[^\^][^ \[\]]+)\]\:(?<text>.+)").unwrap());
+        REGEX.is_match(text)
+    }
+
+    fn collect_with_rope(text: &str, rope: &Rope) -> Vec<MDLinkReferenceDefinition> {
         static REGEX: Lazy<Regex> =
             Lazy::new(|| Regex::new(r"\[(?<index>[^\^][^ \[\]]+)\]\:(?<text>.+)").unwrap());
 
@@ -1516,11 +1571,12 @@ impl MDLinkReferenceDefinition {
             .flat_map(|(full, index, url)| {
                 Some(MDLinkReferenceDefinition {
                     link_ref_name: index.as_str().to_string(),
-                    range: MyRange::from_range(&Rope::from_str(text), full.range()),
+                    range: MyRange::from_range(rope, full.range()),
                     url: url.as_str().trim().to_string(),
                     title: None,
                 })
-            });
+            })
+            .collect();
 
         result
     }
@@ -1794,16 +1850,42 @@ fn matches_path_or_file(file_ref_text: &str, refname: Option<Refname>) -> bool {
 // tests
 #[cfg(test)]
 mod vault_tests {
-    use std::path::Path;
+    use std::path::{Path, PathBuf};
 
     use itertools::Itertools;
     use tower_lsp::lsp_types::{Position, Range};
 
-    use crate::vault::{HeadingLevel, MyRange, ReferenceData};
+    use crate::config::{Case, EmbeddedBlockTransclusionLength, Settings};
+    use crate::vault::{HeadingLevel, ReferenceData};
     use crate::vault::{MDLinkReferenceDefinition, Refname};
 
     use super::Reference::*;
     use super::{MDFile, MDFootnote, MDHeading, MDIndexedBlock, MDTag, Reference, Referenceable};
+
+    fn test_settings() -> Settings {
+        Settings {
+            dailynote: "%Y-%m-%d".into(),
+            new_file_folder_path: String::new(),
+            daily_notes_folder: String::new(),
+            heading_completions: true,
+            title_headings: true,
+            unresolved_diagnostics: true,
+            semantic_tokens: true,
+            tags_in_codeblocks: false,
+            references_in_codeblocks: false,
+            include_md_extension_md_link: false,
+            include_md_extension_wikilink: false,
+            hover: true,
+            case_matching: Case::Smart,
+            inlay_hints: true,
+            block_transclusion: true,
+            block_transclusion_length: EmbeddedBlockTransclusionLength::Full,
+            link_filenames_only: false,
+            excluded_folders: Vec::new(),
+            heading_slug: false,
+            callout_completions: true,
+        }
+    }
 
     #[test]
     fn wiki_link_parsing() {
@@ -3347,5 +3429,27 @@ Some content here";
         })];
 
         assert_eq!(parsed, expected);
+    }
+
+    #[test]
+    #[ignore]
+    fn test_md_file_perf_regression() {
+        let filler = "x".repeat(900);
+        let mut text = String::new();
+
+        for i in 0..4_000 {
+            text.push_str(&format!(
+                "# Heading {i}\n{filler}\n#tag{i}\n[label {i}](note-{i}.md)\n[ref-{i}]: https://example.com/{i}\n"
+            ));
+        }
+
+        let start = std::time::Instant::now();
+        let md_file = MDFile::new(&test_settings(), &text, PathBuf::from("large.md"));
+        let elapsed = start.elapsed();
+
+        assert_eq!(md_file.headings.len(), 4_000);
+        assert_eq!(md_file.tags.len(), 4_000);
+        assert_eq!(md_file.link_reference_definitions.len(), 4_000);
+        assert!(elapsed < std::time::Duration::from_secs(3), "parsing took {elapsed:?}");
     }
 }

--- a/src/vault/mod.rs
+++ b/src/vault/mod.rs
@@ -3432,7 +3432,6 @@ Some content here";
     }
 
     #[test]
-    #[ignore]
     fn test_md_file_perf_regression() {
         let filler = "x".repeat(900);
         let mut text = String::new();
@@ -3450,6 +3449,9 @@ Some content here";
         assert_eq!(md_file.headings.len(), 4_000);
         assert_eq!(md_file.tags.len(), 4_000);
         assert_eq!(md_file.link_reference_definitions.len(), 4_000);
-        assert!(elapsed < std::time::Duration::from_secs(3), "parsing took {elapsed:?}");
+        assert!(
+            elapsed < std::time::Duration::from_secs(3),
+            "parsing took {elapsed:?}"
+        );
     }
 }

--- a/src/vault/parsing.rs
+++ b/src/vault/parsing.rs
@@ -31,11 +31,14 @@ impl MDCodeBlock {
 
         let short_captures = SHORT_RE.captures_iter(text);
 
-        captures.chain(short_captures).flat_map(|captures| {
-            Some(MDCodeBlock {
-                range: MyRange::from_range(rope, captures.name("fullblock")?.range()),
+        captures
+            .chain(short_captures)
+            .flat_map(|captures| {
+                Some(MDCodeBlock {
+                    range: MyRange::from_range(rope, captures.name("fullblock")?.range()),
+                })
             })
-        }).collect()
+            .collect()
     }
 }
 
@@ -295,7 +298,6 @@ fj aklfjd
     }
 
     #[test]
-    #[ignore]
     fn test_inline_code_block_perf_regression() {
         let repeated = "`inline` plain text ".repeat(20_000);
         let test = format!("{repeated}\n```rust\nfn main() {{}}\n```\n{repeated}");
@@ -305,6 +307,9 @@ fj aklfjd
         let elapsed = start.elapsed();
 
         assert_eq!(parsed.len(), 40_001);
-        assert!(elapsed < std::time::Duration::from_secs(3), "parsing took {elapsed:?}");
+        assert!(
+            elapsed < std::time::Duration::from_secs(3),
+            "parsing took {elapsed:?}"
+        );
     }
 }

--- a/src/vault/parsing.rs
+++ b/src/vault/parsing.rs
@@ -10,7 +10,13 @@ pub struct MDCodeBlock {
 }
 
 impl MDCodeBlock {
+    #[cfg(test)]
     pub fn new(text: &str) -> impl Iterator<Item = MDCodeBlock> + '_ {
+        let rope = Rope::from_str(text);
+        Self::collect_with_rope(text, &rope).into_iter()
+    }
+
+    pub fn collect_with_rope(text: &str, rope: &Rope) -> Vec<MDCodeBlock> {
         static RE: Lazy<Regex> = Lazy::new(|| {
             Regex::new(r"(^|\n)(?<fullblock>``` *(?<lang>[^\n]+)?\n(?<code>(\n|.)*?)\n```)")
                 .expect("Codeblock Regex Not Constructing")
@@ -27,12 +33,9 @@ impl MDCodeBlock {
 
         captures.chain(short_captures).flat_map(|captures| {
             Some(MDCodeBlock {
-                range: MyRange::from_range(
-                    &Rope::from_str(text),
-                    captures.name("fullblock")?.range(),
-                ),
+                range: MyRange::from_range(rope, captures.name("fullblock")?.range()),
             })
-        })
+        }).collect()
     }
 }
 
@@ -289,5 +292,19 @@ fj aklfjd
         ];
 
         assert_eq!(parsed, expected)
+    }
+
+    #[test]
+    #[ignore]
+    fn test_inline_code_block_perf_regression() {
+        let repeated = "`inline` plain text ".repeat(20_000);
+        let test = format!("{repeated}\n```rust\nfn main() {{}}\n```\n{repeated}");
+
+        let start = std::time::Instant::now();
+        let parsed = MDCodeBlock::new(&test).collect_vec();
+        let elapsed = start.elapsed();
+
+        assert_eq!(parsed.len(), 40_001);
+        assert!(elapsed < std::time::Duration::from_secs(3), "parsing took {elapsed:?}");
     }
 }


### PR DESCRIPTION
Warning! I am not a Rust dev, however, this AI-generated PR reduces parsing time of large (5 MB)  *.md file from 60 to 1 second.

I've manually tested the result as Zed extension and also run all instructions from docs-dev/PERFORMANCE_LARGE_FILE.md , the performance improvement can be observed in isolation.