### PR TITLE
Ignore inline-code wiki delimiters

### DIFF
--- a/src/vault/mod.rs
+++ b/src/vault/mod.rs
@@ -856,7 +856,7 @@ impl Reference {
 
     pub fn new<'a>(text: &'a str, file_name: &'a str) -> impl Iterator<Item = Reference> + 'a {
         static WIKI_LINK_RE: Lazy<Regex> = Lazy::new(|| {
-            Regex::new(r"\[\[(?<filepath>[^\[\]\|\#]+?)?(?<ending>\.md)?(\#(?<infileref>[^\[\]\|]+))?(\|(?<display>[^\[\]\|]+))?\]\]")
+            Regex::new(r"\[\[(?<filepath>[^`\[\]\|\#]+?)?(?<ending>\.md)?(\#(?<infileref>[^`\[\]\|]+))?(\|(?<display>[^`\[\]\|]+))?\]\]")
 
                 .unwrap()
         }); // A [[link]] that does not have any [ or ] in it
@@ -1803,6 +1803,15 @@ mod vault_tests {
 
     use super::Reference::*;
     use super::{MDFile, MDFootnote, MDHeading, MDIndexedBlock, MDTag, Reference, Referenceable};
+
+
+    #[test]
+    fn wiki_link_delimiters_inside_inline_code_are_ignored() {
+        let text = "* DO NOT use the square bracket `[[` and `]]` markers";
+        let parsed = Reference::new(text, "test.md").collect_vec();
+
+        assert!(parsed.is_empty());
+    }
 
     #[test]
     fn wiki_link_parsing() {


### PR DESCRIPTION
## Summary
- prevent the wiki-link regex from spanning inline-code-delimited literal `[[` / `]]` markers
- add a regression test for the reported bullet text so it no longer produces an unresolved reference

Fixes #269
/claim #269

## Validation
- `git diff --check`
- verified the updated regex locally with Python against the reported string and normal `[[link]]` examples

Note: Rust tooling (`cargo`/`rustc`) is not installed in this runner, so I could not execute the Rust test suite locally.