### PR TITLE
fix(completion): order sortText so higher fuzzy scores rank first

### DIFF
--- a/src/completion/matcher.rs
+++ b/src/completion/matcher.rs
@@ -72,8 +72,12 @@ pub fn fuzzy_match_completions<'a, 'b, C: Completer<'a>, T: Matchable + Completa
 
     normal_fuzzy_match
         .into_iter()
-        .map(|(item, score)| OrderedCompletion::new(item, score.to_string()))
+        .map(|(item, score)| OrderedCompletion::new(item, score_to_sort_text(score)))
         .collect::<Vec<_>>()
+}
+
+fn score_to_sort_text(score: u32) -> String {
+    score.to_string()
 }
 
 pub fn fuzzy_match<T: Matchable>(
@@ -99,4 +103,44 @@ pub fn fuzzy_match<T: Matchable>(
         .into_iter()
         .map(|(item, score)| (item.0, score))
         .collect()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::score_to_sort_text;
+
+    #[test]
+    fn higher_score_sorts_lexicographically_first() {
+        // nucleo returns higher score = better match. LSP clients sort `sortText`
+        // ascending, so a better match must produce a *smaller* string.
+        let better = score_to_sort_text(1000);
+        let worse = score_to_sort_text(10);
+        assert!(
+            better < worse,
+            "better match (1000) should sort before worse (10): {better:?} vs {worse:?}"
+        );
+    }
+
+    #[test]
+    fn digit_count_does_not_invert_order() {
+        // Without zero-padding, "100" is a prefix of "1000" so "100" < "1000"
+        // lexicographically — but 1000 is the better score and must sort first.
+        let s_1000 = score_to_sort_text(1000);
+        let s_100 = score_to_sort_text(100);
+        assert!(
+            s_1000 < s_100,
+            "score 1000 should sort before score 100: {s_1000:?} vs {s_100:?}"
+        );
+    }
+
+    #[test]
+    fn lexicographic_sort_matches_descending_score_order() {
+        let mut entries: Vec<(u32, String)> = [9, 99, 100, 1000, 50, 7]
+            .iter()
+            .map(|&s| (s, score_to_sort_text(s)))
+            .collect();
+        entries.sort_by(|a, b| a.1.cmp(&b.1));
+        let scores: Vec<u32> = entries.iter().map(|(s, _)| *s).collect();
+        assert_eq!(scores, vec![1000, 100, 99, 50, 9, 7]);
+    }
 }

--- a/src/completion/matcher.rs
+++ b/src/completion/matcher.rs
@@ -77,7 +77,12 @@ pub fn fuzzy_match_completions<'a, 'b, C: Completer<'a>, T: Matchable + Completa
 }
 
 fn score_to_sort_text(score: u32) -> String {
-    score.to_string()
+    // LSP clients sort `sortText` ascending and lexicographically. To express
+    // "higher nucleo score = earlier in the list," invert the score so better
+    // matches yield smaller numbers, and zero-pad to a fixed width so every
+    // string compares character-by-character as if it were numeric. u32::MAX
+    // is 10 digits, so 10 places is enough.
+    format!("{:010}", u32::MAX - score)
 }
 
 pub fn fuzzy_match<T: Matchable>(


### PR DESCRIPTION
`fuzzy_match_completions` set each item's `sortText` to `score.to_string()`. LSP clients sort `sortText` ascending and lexicographically, which produced two compounding bugs:

1. **Direction inverted.** Nucleo returns *higher score = better match*, but ascending sort puts smaller numbers first — so worse matches surfaced at the top.
2. **Lexicographic vs numeric.** Without zero-padding, `"100" < "99"` and `"9" > "100"`, so digit count dominated over actual rank.

Most visible in `[[ <query>]]` block-reference completion: when typing e.g. `[[ dreamtime return]]`, unrelated paragraphs that happened to fuzzy-match outranked the actual target.


Current behavior

<img width="429" height="135" alt="image" src="https://github.com/user-attachments/assets/896e2d81-133e-4de6-a154-c096b48ff69e" />

After changes

<img width="429" height="134" alt="image" src="https://github.com/user-attachments/assets/ca93b1b7-d04b-4c89-947f-9553a3c08807" />

### Fix

Encode the score as `format!("{:010}", u32::MAX - score)`:
- inversion makes ascending lexicographic order match descending numeric order (better matches first)
- 10-digit zero-padding fits `u32::MAX` so character-by-character compare equals numeric compare

### Tests

Added unit tests in `src/completion/matcher.rs` covering:
- higher score → smaller `sortText`
- digit-count flips don't invert order (1000 vs 100)
- end-to-end ordering of a mixed-magnitude score set

Full suite: 77 passed, 0 failed.

### Test plan

- [ ] `cargo test`
- [ ] Manually verify wikilink completion (`[[ <query>]]`) ranks relevant matches above paragraph noise