### PR TITLE
Fix wikilink heading action not finding files in sub-directories

### DIFF
--- a/src/codeactions.rs
+++ b/src/codeactions.rs
@@ -11,7 +11,7 @@ use crate::{
     config::Settings,
     daily::filename_is_formatted,
     diagnostics::path_unresolved_references,
-    vault::{Reference, Vault},
+    vault::{Reference, ReferenceData, Vault},
 };
 
 pub fn code_actions(
@@ -71,14 +71,38 @@ pub fn code_actions(
                         }))
                     }
                     Reference::WikiHeadingLink(_data, link_path, heading) => {
+                        // Construct a ref without the heading part to
+                        // check if the file already exists
+                        let reference_data = ReferenceData {
+                            reference_text: _data
+                                .reference_text
+                                .clone()
+                                .split_once('#')
+                                .expect("Heading link contains #")
+                                .0 // Take the file part
+                                .to_string(),
+                            display_text: _data.display_text.clone(),
+                            range: _data.range,
+                        };
+                        let referenceables = vault.select_referenceables_for_reference(
+                            &Reference::WikiFileLink(reference_data),
+                            path,
+                        );
 
-                        let mut new_path_buf = vault.root_dir().clone();
-                        if filename_is_formatted(settings, link_path) {
-                            new_path_buf.push(&settings.daily_notes_folder);
-                        } else {
-                            new_path_buf.push(&settings.new_file_folder_path);
-                        }
-                        new_path_buf.push(link_path);
+                        let mut new_path_buf = referenceables
+                            .first()
+                            .map(|referencable| referencable.get_path().to_path_buf())
+                            .unwrap_or({
+                                let mut new_path_buf = vault.root_dir().clone();
+                                if filename_is_formatted(settings, link_path) {
+                                    new_path_buf.push(&settings.daily_notes_folder);
+                                } else {
+                                    new_path_buf.push(&settings.new_file_folder_path);
+                                }
+                                new_path_buf.push(link_path);
+                                new_path_buf
+                            });
+
                         new_path_buf.set_extension("md");
 
                         let new_path = Url::from_file_path(&new_path_buf).ok()?;


### PR DESCRIPTION
Hey,

I'd like to propose a small fix.

### Issue

Consider a vault:

```bash
vault
├── foo.md # Contains `[[bar#Does Not Exist]]`
└── sub
    └── bar.md
```

Currently running the code action on the unresolved wiki-link will create a new `bar.md` file at the root of the vault (or wherever it's configured) and result in:

```bash
vault
├── bar.md # New file was created
├── foo.md
└── sub
    └── bar.md
```

### Fix

Strip the heading part to create a link only reference - then use the same logic as `gotodef.rs` to find the existing nested file-path.