### PR TITLE
Add workspace symbol alias regression coverage

### DIFF
--- a/src/commands.rs
+++ b/src/commands.rs
@@ -27,6 +27,7 @@ fn date_to_file(date: NaiveDate, dailynote_format: &str, root_dir: &Path) -> Opt
     Url::from_file_path(path.with_extension("md")).ok()
 }
 
+#[cfg(test)]
 fn extract_date_from_filename(filename: &str, dailynote_format: &str) -> Option<NaiveDate> {
     let filename = filename.strip_suffix(".md").unwrap_or(filename);
     NaiveDate::parse_from_str(filename, dailynote_format).ok()

--- a/src/symbol.rs
+++ b/src/symbol.rs
@@ -19,13 +19,12 @@ fn compute_match_score(
 ) -> (u32, SymbolInformation) {
     let mut buf = Vec::new();
     (
-        match pattern.score(
-            nucleo_matcher::Utf32Str::new(symbol.name.as_str(), &mut buf),
-            matcher,
-        ) {
-            None => 0,
-            Some(score) => score,
-        },
+        pattern
+            .score(
+                nucleo_matcher::Utf32Str::new(symbol.name.as_str(), &mut buf),
+                matcher,
+            )
+            .unwrap_or_default(),
         symbol,
     )
 }
@@ -148,10 +147,87 @@ fn map_to_lsp_tree(tree: Vec<Node>) -> Vec<DocumentSymbol> {
 
 #[cfg(test)]
 mod test {
-    use crate::{
-        symbol,
-        vault::{HeadingLevel, MDHeading},
+    use std::{
+        fs,
+        path::PathBuf,
+        time::{SystemTime, UNIX_EPOCH},
     };
+
+    use tower_lsp::lsp_types::{SymbolKind, WorkDoneProgressParams, WorkspaceSymbolParams};
+
+    use crate::{
+        config::{Case, EmbeddedBlockTransclusionLength, Settings},
+        symbol,
+        vault::{HeadingLevel, MDHeading, Vault},
+    };
+
+    fn test_settings() -> Settings {
+        Settings {
+            dailynote: "%Y-%m-%d".into(),
+            new_file_folder_path: "".into(),
+            daily_notes_folder: "".into(),
+            heading_completions: true,
+            title_headings: true,
+            unresolved_diagnostics: true,
+            semantic_tokens: true,
+            tags_in_codeblocks: false,
+            references_in_codeblocks: false,
+            include_md_extension_md_link: false,
+            include_md_extension_wikilink: false,
+            hover: true,
+            case_matching: Case::Smart,
+            inlay_hints: true,
+            block_transclusion: true,
+            block_transclusion_length: EmbeddedBlockTransclusionLength::Full,
+            link_filenames_only: false,
+            excluded_folders: Vec::new(),
+            heading_slug: false,
+            callout_completions: true,
+        }
+    }
+
+    fn temp_vault_path(name: &str) -> PathBuf {
+        let nanos = SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .expect("system clock should be after epoch")
+            .as_nanos();
+
+        std::env::temp_dir().join(format!("{name}-{}-{nanos}", std::process::id()))
+    }
+
+    #[test]
+    fn workspace_symbols_include_frontmatter_aliases() {
+        let root_dir = temp_vault_path("moxide-workspace-symbol-aliases");
+        fs::create_dir_all(&root_dir).unwrap();
+        fs::write(
+            root_dir.join("Project Note.md"),
+            r#"---
+aliases: ["Friendly Alias", "Backup Name"]
+---
+
+# Body
+"#,
+        )
+        .unwrap();
+
+        let vault = Vault::construct_vault(&test_settings(), &root_dir).unwrap();
+        let params = WorkspaceSymbolParams {
+            query: "friendly".into(),
+            partial_result_params: Default::default(),
+            work_done_progress_params: WorkDoneProgressParams::default(),
+        };
+
+        let symbols = super::workspace_symbol(&vault, &params).unwrap();
+        let alias_symbol = symbols
+            .iter()
+            .find(|symbol| symbol.name == "Friendly Alias")
+            .expect("frontmatter alias should be returned as a workspace symbol");
+
+        assert_eq!(alias_symbol.kind, SymbolKind::FILE);
+        assert!(symbols.iter().all(|symbol| symbol.name != "Backup Name"));
+
+        fs::remove_dir_all(root_dir).unwrap();
+    }
 
     #[test]
     fn test_simple_tree() {

--- a/src/ui.rs
+++ b/src/ui.rs
@@ -54,7 +54,7 @@ pub fn preview_referenceable(
     vault: &Vault,
     referenceable: &Referenceable,
 ) -> Option<MarkupContent> {
-    let display = referenceable_string(vault, &[referenceable.clone()])?;
+    let display = referenceable_string(vault, std::slice::from_ref(referenceable))?;
 
     Some(MarkupContent {
         kind: MarkupKind::Markdown,

--- a/src/vault/mod.rs
+++ b/src/vault/mod.rs
@@ -1798,7 +1798,7 @@ mod vault_tests {
     use itertools::Itertools;
     use tower_lsp::lsp_types::{Position, Range};
 
-    use crate::vault::{HeadingLevel, MyRange, ReferenceData};
+    use crate::vault::{HeadingLevel, ReferenceData};
     use crate::vault::{MDLinkReferenceDefinition, Refname};
 
     use super::Reference::*;
@@ -3325,7 +3325,7 @@ Some content here";
 
     #[test]
     fn parse_weird_url_encoded_file_link() {
-        let text = "[f](%D1%84%D0%B0%D0%B9%D0%BB%20with%20%C3%A9mojis%20%F0%9F%9A%80%20%26%20symbols%20%21%23%40%24%25%26%2A%28%29%2B%3D%7B%7D%7C%5C%22%5C%5C%3A%3B%3F)".into();
+        let text = "[f](%D1%84%D0%B0%D0%B9%D0%BB%20with%20%C3%A9mojis%20%F0%9F%9A%80%20%26%20symbols%20%21%23%40%24%25%26%2A%28%29%2B%3D%7B%7D%7C%5C%22%5C%5C%3A%3B%3F)";
 
         let parsed = Reference::new(text, "test.md").collect_vec();
 


### PR DESCRIPTION
## Summary
- add a workspace-symbol regression test that builds a vault with YAML frontmatter aliases and verifies an alias query returns a FILE symbol
- keep the workspace-symbol matcher clippy-clean while preserving existing scoring behavior
- clean up small existing clippy warnings so strict local linting passes

## Validation
- cargo fmt --check
- cargo test
- cargo clippy --all-targets -- -D warnings
- cargo check

/claim #263