### PR TITLE
New setting: complete_paths_as_relative_to_vault

### DIFF
--- a/docs/Markdown Oxide Docs/Configuration.md
+++ b/docs/Markdown Oxide Docs/Configuration.md
@@ -85,6 +85,11 @@ heading_slug = false
 # Files within excluded folders will not appear in completions, references, diagnostics, or other LSP features
 # Matching is by directory name, so excluding "Archive" will skip any directory named Archive at any depth
 excluded_folders = []
+
+# Complete paths as relative to vault
+# If disabled, vault/subdir/file.md completed as [[file]]
+# If enabled, it completes as [[subdir/file]]
+complete_paths_as_relative_to_vault = false
 ```
 
 # Daily Note Format Config Option

--- a/src/completion/link_completer.rs
+++ b/src/completion/link_completer.rs
@@ -19,7 +19,9 @@ use crate::{
     completion::util::check_in_code_block,
     config::Settings,
     ui::preview_referenceable,
-    vault::{heading_to_slug, MDFile, MDHeading, Reference, Referenceable, Vault},
+    vault::{
+        get_obsidian_ref_path, heading_to_slug, MDFile, MDHeading, Reference, Referenceable, Vault,
+    },
 };
 
 use super::{
@@ -613,6 +615,14 @@ impl LinkCompletion<'_> {
         referenceable: Referenceable<'a>,
         completer: &impl LinkCompleter<'a>,
     ) -> Option<Vec<LinkCompletion<'a>>> {
+        let get_path_as_obsidian_relative = |path: &PathBuf| -> Option<String> {
+            if completer.settings().complete_paths_as_relative_to_vault {
+                get_obsidian_ref_path(completer.vault().root_dir(), path)
+            } else {
+                Some(String::from(path.file_stem()?.to_str()?))
+            }
+        };
+
         if let Some(daily) = MDDailyNote::from_referenceable(referenceable.clone(), completer) {
             Some(vec![DailyNote(daily)])
         } else {
@@ -621,7 +631,7 @@ impl LinkCompletion<'_> {
                     Some(
                         once(File {
                             mdfile,
-                            match_string: mdfile.file_name()?.to_string(),
+                            match_string: get_path_as_obsidian_relative(&mdfile.path)?,
                             referenceable: referenceable.clone(),
                         })
                         .chain(mdfile.metadata.iter().flat_map(|it| it.aliases()).flat_map(
@@ -647,7 +657,7 @@ impl LinkCompletion<'_> {
                             heading: mdheading,
                             match_string: format!(
                                 "{}#{}",
-                                path.file_stem()?.to_str()?,
+                                get_path_as_obsidian_relative(path)?,
                                 heading_text
                             ),
                             referenceable,
@@ -657,7 +667,11 @@ impl LinkCompletion<'_> {
                 }
                 Referenceable::IndexedBlock(path, indexed) => Some(
                     once(Block {
-                        match_string: format!("{}#^{}", path.file_stem()?.to_str()?, indexed.index),
+                        match_string: format!(
+                            "{}#^{}",
+                            get_path_as_obsidian_relative(path)?,
+                            indexed.index
+                        ),
                         referenceable,
                     })
                     .collect(),

--- a/src/config.rs
+++ b/src/config.rs
@@ -28,10 +28,10 @@ pub struct Settings {
     pub block_transclusion: bool,
     pub block_transclusion_length: EmbeddedBlockTransclusionLength,
     pub link_filenames_only: bool,
-    /// Folders to exclude from vault indexing (e.g. ["Archive", "Templates"])
     pub excluded_folders: Vec<String>,
     pub heading_slug: bool,
     pub callout_completions: bool,
+    pub complete_paths_as_relative_to_vault: bool,
 }
 
 #[derive(Clone, Debug, Deserialize)]
@@ -103,6 +103,7 @@ impl Settings {
             .set_default("excluded_folders", Vec::<String>::new())?
             .set_default("heading_slug", false)?
             .set_default("callout_completions", true)?
+            .set_default("complete_paths_as_relative_to_vault", false)?
             .build()
             .map_err(|err| anyhow!("Build err: {err}"))?;
 


### PR DESCRIPTION
Alternative implementation of https://github.com/Feel-ix-343/markdown-oxide/issues/219

Please see also https://github.com/Feel-ix-343/markdown-oxide/pull/402. Although this is slightly less robust, it offers a UX closer to what Obsidian offers for fuzzy finding by allowing completions of partial **directory and file** names. For example, if you have the vault-relative path `folder/Fiile.md`, then we expect the following texts to be auto-completed as `[[folder/Fiile]]`:

| | This implementation | https://github.com/Feel-ix-343/markdown-oxide/pull/402 |
| --- | --- | --- |
| `[[Fii` | :heavy_check_mark:  | :heavy_check_mark: |
| `[[fol` | :heavy_check_mark:  | :heavy_check_mark: |
| `[[Fiifol` | :heavy_check_mark:  | :x: |

This implementation also seems simpler at first glance.