### PR TITLE
Ignore wikilink markers overlapping inline code

### DIFF
--- a/src/vault/mod.rs
+++ b/src/vault/mod.rs
@@ -601,6 +601,18 @@ pub trait Rangeable {
                     && self_range.end.character >= other_range.end.character))
     }
 
+    fn overlaps(&self, other: &impl Rangeable) -> bool {
+        fn before_or_touching(left: Position, right: Position) -> bool {
+            left.line < right.line || (left.line == right.line && left.character <= right.character)
+        }
+
+        let self_range = self.range();
+        let other_range = other.range();
+
+        !before_or_touching(self_range.end, other_range.start)
+            && !before_or_touching(other_range.end, self_range.start)
+    }
+
     fn includes_position(&self, position: Position) -> bool {
         let range = self.range();
         (range.start.line < position.line
@@ -672,7 +684,7 @@ impl MDFile {
                 references_in_codeblocks: false,
                 ..
             } => Reference::new(text, file_name)
-                .filter(|it| !code_blocks.iter().any(|codeblock| codeblock.includes(it)))
+                .filter(|it| !code_blocks.iter().any(|codeblock| codeblock.overlaps(it)))
                 .collect_vec(),
             _ => Reference::new(text, file_name).collect_vec(),
         };
@@ -1798,11 +1810,37 @@ mod vault_tests {
     use itertools::Itertools;
     use tower_lsp::lsp_types::{Position, Range};
 
-    use crate::vault::{HeadingLevel, MyRange, ReferenceData};
+    use crate::config::{Case, EmbeddedBlockTransclusionLength, Settings};
+    use crate::vault::{HeadingLevel, ReferenceData};
     use crate::vault::{MDLinkReferenceDefinition, Refname};
 
     use super::Reference::*;
     use super::{MDFile, MDFootnote, MDHeading, MDIndexedBlock, MDTag, Reference, Referenceable};
+
+    fn test_settings(references_in_codeblocks: bool) -> Settings {
+        Settings {
+            dailynote: "%Y-%m-%d".into(),
+            new_file_folder_path: String::new(),
+            daily_notes_folder: String::new(),
+            heading_completions: true,
+            title_headings: true,
+            unresolved_diagnostics: true,
+            semantic_tokens: true,
+            tags_in_codeblocks: false,
+            references_in_codeblocks,
+            include_md_extension_md_link: false,
+            include_md_extension_wikilink: false,
+            hover: true,
+            case_matching: Case::Smart,
+            inlay_hints: true,
+            block_transclusion: true,
+            block_transclusion_length: EmbeddedBlockTransclusionLength::Full,
+            link_filenames_only: false,
+            excluded_folders: Vec::new(),
+            heading_slug: false,
+            callout_completions: true,
+        }
+    }
 
     #[test]
     fn wiki_link_parsing() {
@@ -1858,6 +1896,31 @@ mod vault_tests {
         ];
 
         assert_eq!(parsed, expected)
+    }
+
+    #[test]
+    fn wiki_link_markers_split_across_inline_code_are_not_references() {
+        let text = "* DO NOT use the square bracket `[[` and `]]` markers";
+        let parsed = MDFile::new(
+            &test_settings(false),
+            text,
+            Path::new("test.md").to_path_buf(),
+        );
+
+        assert!(parsed.references.is_empty());
+    }
+
+    #[test]
+    fn wiki_link_adjacent_to_inline_code_is_still_a_reference() {
+        let text = "`code`[[Real Note]]";
+        let parsed = MDFile::new(
+            &test_settings(false),
+            text,
+            Path::new("test.md").to_path_buf(),
+        );
+
+        assert_eq!(parsed.references.len(), 1);
+        assert_eq!(parsed.references[0].data().reference_text, "Real Note");
     }
 
     #[test]


### PR DESCRIPTION
Fixes #269

/claim #269

## Summary
- add a range-overlap helper so references that touch inline or fenced code spans can be filtered when references_in_codeblocks is disabled
- filter references by overlap with code spans instead of only full containment, which removes the false wikilink created by literal inline-code [[ and ]] markers
- keep adjacent real wikilinks intact with a regression test

## Verification
- cargo fmt --check
- cargo test inline_code -- --nocapture
- cargo test
- git diff --check