### PR TITLE
Don't parse wikilink references inside inline code / code blocks (#269)

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -41,10 +41,49 @@ pub enum Case {
     Respect,
 }
 
+impl Default for Case {
+    fn default() -> Self {
+        Case::Smart
+    }
+}
+
 #[derive(Clone, Debug, Deserialize)]
 pub enum EmbeddedBlockTransclusionLength {
     Partial(usize),
     Full,
+}
+
+impl Default for EmbeddedBlockTransclusionLength {
+    fn default() -> Self {
+        EmbeddedBlockTransclusionLength::Full
+    }
+}
+
+impl Default for Settings {
+    fn default() -> Self {
+        Settings {
+            dailynote: "%Y-%m-%d".into(),
+            new_file_folder_path: "".into(),
+            daily_notes_folder: "".into(),
+            heading_completions: true,
+            title_headings: true,
+            unresolved_diagnostics: true,
+            semantic_tokens: true,
+            tags_in_codeblocks: false,
+            references_in_codeblocks: false,
+            include_md_extension_md_link: false,
+            include_md_extension_wikilink: false,
+            hover: true,
+            case_matching: Case::default(),
+            inlay_hints: true,
+            block_transclusion: true,
+            block_transclusion_length: EmbeddedBlockTransclusionLength::default(),
+            link_filenames_only: false,
+            excluded_folders: vec![],
+            heading_slug: false,
+            callout_completions: true,
+        }
+    }
 }
 
 impl Settings {

--- a/src/vault/mod.rs
+++ b/src/vault/mod.rs
@@ -602,14 +602,15 @@ pub trait Rangeable {
     }
 
     fn overlaps(&self, other: &impl Rangeable) -> bool {
-        fn before(left: Position, right: Position) -> bool {
-            left.line < right.line || (left.line == right.line && left.character < right.character)
+        fn before_or_equal(left: Position, right: Position) -> bool {
+            left.line < right.line || (left.line == right.line && left.character <= right.character)
         }
 
         let self_range = self.range();
         let other_range = other.range();
 
-        before(self_range.start, other_range.end) && before(other_range.start, self_range.end)
+        before_or_equal(self_range.start, other_range.end)
+            && before_or_equal(other_range.start, self_range.end)
     }
 
     fn includes_position(&self, position: Position) -> bool {
@@ -1809,8 +1810,8 @@ mod vault_tests {
     use itertools::Itertools;
     use tower_lsp::lsp_types::{Position, Range};
 
-    use crate::config::{Case, EmbeddedBlockTransclusionLength, Settings};
-    use crate::vault::{HeadingLevel, MyRange, ReferenceData};
+    use crate::config::Settings;
+    use crate::vault::{HeadingLevel, ReferenceData};
     use crate::vault::{MDLinkReferenceDefinition, Refname};
 
     use super::Reference::*;
@@ -1818,26 +1819,8 @@ mod vault_tests {
 
     fn test_settings() -> Settings {
         Settings {
-            dailynote: "%Y-%m-%d".into(),
-            new_file_folder_path: "".into(),
-            daily_notes_folder: "".into(),
-            heading_completions: true,
-            title_headings: true,
-            unresolved_diagnostics: true,
-            semantic_tokens: true,
-            tags_in_codeblocks: false,
             references_in_codeblocks: false,
-            include_md_extension_md_link: false,
-            include_md_extension_wikilink: false,
-            hover: true,
-            case_matching: Case::Smart,
-            inlay_hints: true,
-            block_transclusion: true,
-            block_transclusion_length: EmbeddedBlockTransclusionLength::Full,
-            link_filenames_only: false,
-            excluded_folders: vec![],
-            heading_slug: false,
-            callout_completions: true,
+            ..Settings::default()
         }
     }
 

--- a/src/vault/mod.rs
+++ b/src/vault/mod.rs
@@ -601,6 +601,17 @@ pub trait Rangeable {
                     && self_range.end.character >= other_range.end.character))
     }
 
+    fn overlaps(&self, other: &impl Rangeable) -> bool {
+        fn before(left: Position, right: Position) -> bool {
+            left.line < right.line || (left.line == right.line && left.character < right.character)
+        }
+
+        let self_range = self.range();
+        let other_range = other.range();
+
+        before(self_range.start, other_range.end) && before(other_range.start, self_range.end)
+    }
+
     fn includes_position(&self, position: Position) -> bool {
         let range = self.range();
         (range.start.line < position.line
@@ -672,7 +683,7 @@ impl MDFile {
                 references_in_codeblocks: false,
                 ..
             } => Reference::new(text, file_name)
-                .filter(|it| !code_blocks.iter().any(|codeblock| codeblock.includes(it)))
+                .filter(|it| !code_blocks.iter().any(|codeblock| codeblock.overlaps(it)))
                 .collect_vec(),
             _ => Reference::new(text, file_name).collect_vec(),
         };
@@ -1793,16 +1804,42 @@ fn matches_path_or_file(file_ref_text: &str, refname: Option<Refname>) -> bool {
 // tests
 #[cfg(test)]
 mod vault_tests {
-    use std::path::Path;
+    use std::path::{Path, PathBuf};
 
     use itertools::Itertools;
     use tower_lsp::lsp_types::{Position, Range};
 
+    use crate::config::{Case, EmbeddedBlockTransclusionLength, Settings};
     use crate::vault::{HeadingLevel, MyRange, ReferenceData};
     use crate::vault::{MDLinkReferenceDefinition, Refname};
 
     use super::Reference::*;
     use super::{MDFile, MDFootnote, MDHeading, MDIndexedBlock, MDTag, Reference, Referenceable};
+
+    fn test_settings() -> Settings {
+        Settings {
+            dailynote: "%Y-%m-%d".into(),
+            new_file_folder_path: "".into(),
+            daily_notes_folder: "".into(),
+            heading_completions: true,
+            title_headings: true,
+            unresolved_diagnostics: true,
+            semantic_tokens: true,
+            tags_in_codeblocks: false,
+            references_in_codeblocks: false,
+            include_md_extension_md_link: false,
+            include_md_extension_wikilink: false,
+            hover: true,
+            case_matching: Case::Smart,
+            inlay_hints: true,
+            block_transclusion: true,
+            block_transclusion_length: EmbeddedBlockTransclusionLength::Full,
+            link_filenames_only: false,
+            excluded_folders: vec![],
+            heading_slug: false,
+            callout_completions: true,
+        }
+    }
 
     #[test]
     fn wiki_link_parsing() {
@@ -1856,6 +1893,31 @@ mod vault_tests {
                 ..ReferenceData::default()
             }),
         ];
+
+        assert_eq!(parsed, expected)
+    }
+
+    #[test]
+    fn wikilink_markers_in_inline_code_are_not_references() {
+        let text = "* DO NOT use the square bracket `[[` and `]]` markers\nA real [[Note]]";
+
+        let parsed = MDFile::new(&test_settings(), text, PathBuf::from("test.md")).references;
+
+        let expected = vec![WikiFileLink(ReferenceData {
+            reference_text: "Note".into(),
+            range: tower_lsp::lsp_types::Range {
+                start: tower_lsp::lsp_types::Position {
+                    line: 1,
+                    character: 7,
+                },
+                end: tower_lsp::lsp_types::Position {
+                    line: 1,
+                    character: 15,
+                },
+            }
+            .into(),
+            ..ReferenceData::default()
+        })];
 
         assert_eq!(parsed, expected)
     }


### PR DESCRIPTION
Closes #269.

`[[` / `]]` appearing inside an **inline code span** were parsed as a wikilink reference and flagged "unresolved" — e.g.:

    * DO NOT use the square bracket `[[` and `]]` markers

### Root cause
With `references_in_codeblocks: false`, references were dropped only when **fully contained** in a single code span (`code_blocks.iter().any(|cb| cb.includes(it))`). Here the reference range spans *from* one inline-code span (`` `[[` ``) *to* another (`` `]]` ``), so it isn't contained in any single span and slipped through.

### Fix
Added `Rangeable::overlaps` and changed the filter to drop any reference whose range **overlaps** a code span/block. Real `[[wikilinks]]` outside code are unaffected.

### Test
Added `wikilink_markers_in_inline_code_are_not_references` (the exact issue text → only the real outside `[[Note]]` parses). `cargo test` passes locally.

/claim #269
