### PR TITLE
test: cover workspace symbol aliases

### DIFF
--- a/src/symbol.rs
+++ b/src/symbol.rs
@@ -148,10 +148,67 @@ fn map_to_lsp_tree(tree: Vec<Node>) -> Vec<DocumentSymbol> {
 
 #[cfg(test)]
 mod test {
-    use crate::{
-        symbol,
-        vault::{HeadingLevel, MDHeading},
+    use std::{
+        fs,
+        time::{SystemTime, UNIX_EPOCH},
     };
+
+    use tower_lsp::lsp_types::{ClientCapabilities, WorkspaceSymbolParams};
+
+    use crate::{
+        config::Settings,
+        symbol,
+        vault::{HeadingLevel, MDHeading, Vault},
+    };
+
+    #[test]
+    fn workspace_symbols_include_frontmatter_aliases() {
+        let suffix = SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .expect("system clock should be after unix epoch")
+            .as_nanos();
+        let root = std::env::temp_dir().join(format!("markdown-oxide-symbol-alias-{suffix}"));
+
+        fs::create_dir_all(&root).expect("test vault should be created");
+        fs::write(
+            root.join("Project Notes.md"),
+            "---\naliases: [Roadmap, LaunchPlan]\n---\n\n# Current work\n",
+        )
+        .expect("test note should be written");
+
+        let settings = Settings::new(&root, &ClientCapabilities::default()).unwrap();
+        let vault = Vault::construct_vault(&settings, &root).unwrap();
+
+        let all_symbols = super::workspace_symbol(
+            &vault,
+            &WorkspaceSymbolParams {
+                query: String::new(),
+                work_done_progress_params: Default::default(),
+                partial_result_params: Default::default(),
+            },
+        )
+        .unwrap();
+
+        assert!(all_symbols.iter().any(|symbol| symbol.name == "Project Notes"));
+        assert!(all_symbols.iter().any(|symbol| symbol.name == "Roadmap"));
+        assert!(all_symbols.iter().any(|symbol| symbol.name == "LaunchPlan"));
+
+        let matching_symbols = super::workspace_symbol(
+            &vault,
+            &WorkspaceSymbolParams {
+                query: "LaunchPlan".to_string(),
+                work_done_progress_params: Default::default(),
+                partial_result_params: Default::default(),
+            },
+        )
+        .unwrap();
+
+        assert!(matching_symbols
+            .iter()
+            .any(|symbol| symbol.name == "LaunchPlan"));
+
+        fs::remove_dir_all(root).expect("test vault should be removed");
+    }
 
     #[test]
     fn test_simple_tree() {


### PR DESCRIPTION
## Summary

- adds regression coverage for workspace symbols backed by frontmatter aliases
- checks both the empty-query symbol list and a filtered alias query
- keeps the existing filename symbol behavior covered in the same fixture

Closes #263.

## Verification

`cargo test workspace_symbols_include_frontmatter_aliases` was not runnable in my local Windows environment because `cargo` is not installed there. The change is test-only and `git diff --check` passes locally.