### PR TITLE
[codex] bump version to 0.25.12

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -910,7 +910,7 @@ dependencies = [
 
 [[package]]
 name = "markdown-oxide"
-version = "0.25.11"
+version = "0.25.12"
 dependencies = [
  "anyhow",
  "chrono",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "markdown-oxide"
-version = "0.25.11"
+version = "0.25.12"
 edition = "2021"
 repository = "https://github.com/Feel-ix-343/markdown-oxide"
 


### PR DESCRIPTION
## Summary

Bumps markdown-oxide from `0.25.11` to `0.25.12` in `Cargo.toml` and `Cargo.lock`.

## Validation

- `cargo fmt --check`
- `cargo test` (77 passed)
