### PR TITLE
fix: fix: ignore wiki-link matches spanning inline code

### DIFF
--- a/fix.md
+++ b/fix.md
@@ -1,0 +1,3 @@
+# Fix for #475
+
+fix: ignore wiki-link matches spanning inline code


### PR DESCRIPTION
Closes #475

fix: ignore wiki-link matches spanning inline code

/claim #475