### PR TITLE
fix: ignore wiki-links inside indented list-item code fences (#471)

### DIFF
--- a/src/vault/mod.rs
+++ b/src/vault/mod.rs
@@ -3342,6 +3342,43 @@ Some content here";
     }
 
     #[test]
+    fn indented_fenced_codeblock_in_list_is_not_a_wikilink() {
+        // https://github.com/Feel-ix-343/markdown-oxide/issues/471
+        // `references_in_codeblocks` defaults to false. An indented fence that is
+        // part of a list item must still suppress wiki-link references inside it.
+        let text = "# Title\n\n1. List item\n\n   ```toml\n   [[not_actually_a_wikilink_but_gives_unresolved_reference]]\n   ```\n\n2. Another list item\n";
+
+        let parsed = MDFile::new(&test_settings(), text, PathBuf::from("list.md"));
+
+        assert!(
+            !parsed.references.iter().any(|reference| {
+                matches!(
+                    reference,
+                    WikiFileLink(data)
+                        if data.reference_text == "not_actually_a_wikilink_but_gives_unresolved_reference"
+                )
+            }),
+            "indented list-item fence should hide wiki-link: {:?}",
+            parsed.references
+        );
+    }
+
+    #[test]
+    fn unindented_fenced_codeblock_is_not_a_wikilink() {
+        let text = "# Title\n\n1. List item\n\n```toml\n[[still_not_actually_a_wikilink_and_not_an_unresolved_reference]]\n```\n\n2. Another list item\n";
+
+        let parsed = MDFile::new(&test_settings(), text, PathBuf::from("list.md"));
+
+        assert!(!parsed.references.iter().any(|reference| {
+            matches!(
+                reference,
+                WikiFileLink(data)
+                    if data.reference_text == "still_not_actually_a_wikilink_and_not_an_unresolved_reference"
+            )
+        }));
+    }
+
+    #[test]
     fn mdfile_indexes_first_10k_lines() {
         let text = format!(
             "{}[[inside cap]]\n",

--- a/src/vault/parsing.rs
+++ b/src/vault/parsing.rs
@@ -12,7 +12,10 @@ pub struct MDCodeBlock {
 impl MDCodeBlock {
     pub fn new(text: &str) -> impl Iterator<Item = MDCodeBlock> + '_ {
         static RE: Lazy<Regex> = Lazy::new(|| {
-            Regex::new(r"(^|\n)(?<fullblock>``` *(?<lang>[^\n]+)?\n(?<code>(\n|.)*?)\n```)")
+            // Allow CommonMark / list-item indentation before opening and closing
+            // fences. `(^|\n)```...``` ` missed indented fences inside lists, so
+            // wiki-links in those blocks were treated as references (#471).
+            Regex::new(r"(^|\n)[ \t]*(?<fullblock>```[^\n]*\n(?<code>(\n|.)*?)\n[ \t]*```)")
                 .expect("Codeblock Regex Not Constructing")
         });
 
@@ -226,6 +229,30 @@ fj aklfjd
                 .into(),
             },
         ];
+
+        assert_eq!(parsed, expected)
+    }
+
+    #[test]
+    fn test_indented_fenced_codeblock_in_list_item() {
+        // Fences inside list items are indented; they must still be code blocks.
+        let test = "1. List item\n\n   ```toml\n   [[not_a_wikilink]]\n   ```\n";
+
+        let parsed = MDCodeBlock::new(test).collect_vec();
+
+        let expected = vec![MDCodeBlock {
+            range: Range {
+                start: Position {
+                    line: 2,
+                    character: 3,
+                },
+                end: Position {
+                    line: 4,
+                    character: 6,
+                },
+            }
+            .into(),
+        }];
 
         assert_eq!(parsed, expected)
     }


### PR DESCRIPTION
Fixes #471

Fenced code inside a list item is indented, for example a list item that contains a toml fence with `[[...]]` inside it.

The fence regex required the opening and closing fences at column 0, so those blocks were not treated as code. With `references_in_codeblocks` defaulting to false, the inner wiki-link still produced an Unresolved Reference.

Allow leading spaces/tabs on both fences.

Covering tests:

- `test_indented_fenced_codeblock_in_list_item` — the fence range is detected
- `indented_fenced_codeblock_in_list_is_not_a_wikilink` — no WikiFileLink for the inner wiki-link
- `unindented_fenced_codeblock_is_not_a_wikilink` — the unindented case is still suppressed