### PR TITLE
fix: prevent LSP hang on wrapped parenthetical markdown links (#466)

### DIFF
--- a/src/tokens.rs
+++ b/src/tokens.rs
@@ -2,9 +2,49 @@ use std::{collections::HashSet, iter, path::Path};
 
 use itertools::Itertools;
 use rayon::iter::{IntoParallelIterator, ParallelIterator};
-use tower_lsp::lsp_types::{SemanticToken, SemanticTokensParams, SemanticTokensResult};
+use ropey::Rope;
+use tower_lsp::lsp_types::{
+    Position, Range, SemanticToken, SemanticTokensParams, SemanticTokensResult,
+};
 
 use crate::{config::Settings, diagnostics::path_unresolved_references, vault::Vault};
+
+/// LSP semantic tokens are single-line. A wrapped `[text](url)` has
+/// `end.character < start.character`, so subtracting the columns underflows
+/// `u32` in release (the client then spins on a ~4e9-length token — #466).
+fn semantic_token_length(range: Range, rope: Option<&Rope>) -> u32 {
+    if range.end.line == range.start.line {
+        return range
+            .end
+            .character
+            .saturating_sub(range.start.character);
+    }
+
+    let Some(rope) = rope else {
+        return 1;
+    };
+    let line_idx = range.start.line as usize;
+    if line_idx >= rope.len_lines() {
+        return 1;
+    }
+    let line = rope.line(line_idx);
+    let mut line_chars = line.len_chars() as u32;
+    if line.get_char(line.len_chars().saturating_sub(1)) == Some('\n') {
+        line_chars = line_chars.saturating_sub(1);
+    }
+    if line.get_char(line.len_chars().saturating_sub(1)) == Some('\r') {
+        line_chars = line_chars.saturating_sub(1);
+    }
+    line_chars.saturating_sub(range.start.character).max(1)
+}
+
+fn saturating_delta_start(curr: Position, prev: Position) -> u32 {
+    if curr.line == prev.line {
+        curr.character.saturating_sub(prev.character)
+    } else {
+        curr.character
+    }
+}
 
 pub fn semantic_tokens_full(
     vault: &Vault,
@@ -17,6 +57,7 @@ pub fn semantic_tokens_full(
     }
 
     let references_in_file = vault.select_references(Some(path))?;
+    let rope = vault.ropes.get(path);
 
     let path_unresolved: Option<HashSet<_>> =
         path_unresolved_references(vault, path).map(|thing| {
@@ -36,6 +77,7 @@ pub fn semantic_tokens_full(
         })
         .fold(vec![], |acc, (_path, reference)| {
             let range = reference.data().range;
+            let length = semantic_token_length(range.0, rope);
 
             let is_unresolved = path_unresolved
                 .as_ref()
@@ -47,7 +89,7 @@ pub fn semantic_tokens_full(
                     SemanticToken {
                         delta_line: range.start.line,
                         delta_start: range.start.character,
-                        length: range.end.character - range.start.character,
+                        length,
                         token_type: if is_unresolved { 1 } else { 0 },
                         token_modifiers_bitset: 0,
                     },
@@ -57,13 +99,15 @@ pub fn semantic_tokens_full(
                     .chain(iter::once((
                         reference,
                         SemanticToken {
-                            delta_line: range.start.line - prev_ref.data().range.start.line,
-                            delta_start: if range.start.line == prev_ref.data().range.start.line {
-                                range.start.character - prev_ref.data().range.start.character
-                            } else {
-                                range.start.character
-                            },
-                            length: range.end.character - range.start.character,
+                            delta_line: range
+                                .start
+                                .line
+                                .saturating_sub(prev_ref.data().range.start.line),
+                            delta_start: saturating_delta_start(
+                                range.start,
+                                prev_ref.data().range.start,
+                            ),
+                            length,
                             token_type: if is_unresolved { 1 } else { 0 },
                             token_modifiers_bitset: 0,
                         },
@@ -81,4 +125,70 @@ pub fn semantic_tokens_full(
             data: tokens,
         },
     ))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::{fs, path::PathBuf};
+    use tower_lsp::lsp_types::{
+        ClientCapabilities, PartialResultParams, Position, Range, SemanticTokens,
+        SemanticTokensParams, TextDocumentIdentifier, Url, WorkDoneProgressParams,
+    };
+
+    fn settings() -> Settings {
+        Settings::new(Path::new("."), &ClientCapabilities::default()).unwrap()
+    }
+
+    #[test]
+    fn wrapped_link_token_length_does_not_underflow() {
+        // Naive `end.character - start.character` wraps u32 when the link
+        // text breaks across a line (end column is smaller than start).
+        let text = "# Lorem\n\nSed ut perspiciatis unde omnis iste natus error (see [natus\nerror](#sit)) sit.\n";
+        let rope = Rope::from_str(text);
+        let range = Range {
+            start: Position {
+                line: 2,
+                character: 40,
+            },
+            end: Position {
+                line: 3,
+                character: 5,
+            },
+        };
+        let len = semantic_token_length(range, Some(&rope));
+        assert!(
+            len > 0 && len < 200,
+            "expected first-line remainder, got {len}"
+        );
+    }
+
+    #[test]
+    fn parenthetical_wrapped_md_link_semantic_tokens_are_bounded() {
+        // https://github.com/Feel-ix-343/markdown-oxide/issues/466
+        let text = "# Lorem Ipsum\n\nSed ut perspiciatis unde omnis iste natus error (see [natus\nerror](#sit)) sit voluptatem accusantium doloremque laudantium.\n";
+        let dir = std::env::temp_dir().join("mdoxide-issue-466");
+        fs::create_dir_all(&dir).unwrap();
+        let path: PathBuf = dir.join("hang.md");
+        fs::write(&path, text).unwrap();
+
+        let vault = Vault::construct_vault(&settings(), &dir).unwrap();
+        let params = SemanticTokensParams {
+            text_document: TextDocumentIdentifier {
+                uri: Url::parse("file:///hang.md").unwrap(),
+            },
+            work_done_progress_params: WorkDoneProgressParams::default(),
+            partial_result_params: PartialResultParams::default(),
+        };
+
+        let result = semantic_tokens_full(&vault, &path, params, &settings())
+            .expect("semantic tokens enabled by default");
+        let SemanticTokensResult::Tokens(SemanticTokens { data, .. }) = result else {
+            panic!("expected a token list");
+        };
+        assert!(
+            data.iter().all(|token| token.length < 10_000),
+            "wrapped parenthetical link produced a huge token length: {data:?}"
+        );
+    }
 }


### PR DESCRIPTION
Fixes #466

Wrapped markdown links such as a parenthetical `[text](#url)` that spans a newline produce a Range whose end column is smaller than the start column (the newline resets the column). Semantic tokens then computed `length: end.character - start.character`.

On a debug build that panics (subtract with overflow). In release it wraps to a huge length, and the LSP client spins at 100% CPU — matching the report that the hang is on the client while the server is attached.

Compute a saturating, single-line token length (the rest of the start line from the rope). Same-line tokens are unchanged.

Covering tests:

- `wrapped_link_token_length_does_not_underflow` — first-line remainder is a small positive length
- `parenthetical_wrapped_md_link_semantic_tokens_are_bounded` — the issue's hang.md snippet; every token length stays bounded