### PR TITLE
Fix false references formed by link delimiters inside code

### DIFF
--- a/src/vault/mod.rs
+++ b/src/vault/mod.rs
@@ -682,7 +682,16 @@ impl MDFile {
                 references_in_codeblocks: false,
                 ..
             } => Reference::new(text, file_name)
-                .filter(|it| !code_blocks.iter().any(|codeblock| codeblock.includes(it)))
+                .filter(|reference| {
+                    !code_blocks.iter().any(|codeblock| {
+                        let code = codeblock.range();
+                        let link = reference.range();
+                        // Delimiters inside separate code spans can form one regex match.
+                        // Keep links with code only in their labels and treat ends as exclusive.
+                        (code.start <= link.start && link.start < code.end)
+                            || (code.start < link.end && link.end <= code.end)
+                    })
+                })
                 .collect_vec(),
             _ => Reference::new(text, file_name).collect_vec(),
         };
@@ -1820,6 +1829,65 @@ mod vault_tests {
 
     fn test_settings() -> Settings {
         Settings::new(Path::new("."), &ClientCapabilities::default()).unwrap()
+    }
+
+    #[test]
+    fn reference_boundaries_inside_code_are_ignored() {
+        for text in [
+            "* DO NOT use the square bracket `[[` and `]]` markers",
+            "`[[literal]]`",
+            "`[[` literal ]]",
+            "[[ literal `]]`",
+            "```md\n[[literal]]\n```",
+            "```md\n[[literal\n```\n]]",
+            "[[literal\n```md\n]]\n```",
+        ] {
+            let mut settings = test_settings();
+            settings.references_in_codeblocks = false;
+            let parsed = MDFile::new(&settings, text, PathBuf::from("test.md"));
+            assert!(
+                parsed.references.is_empty(),
+                "{text:?}: {:?}",
+                parsed.references
+            );
+        }
+    }
+
+    #[test]
+    fn reference_boundaries_outside_code_are_preserved() {
+        for text in [
+            "`example`[[target]]",
+            "[[target]]`example`",
+            "`before`[[target]]`after`",
+            "[[target|`code label`]]",
+            "[a `code` label](target.md)",
+            "```md\nexample\n```\n[[target]]",
+        ] {
+            let mut settings = test_settings();
+            settings.references_in_codeblocks = false;
+            let parsed = MDFile::new(&settings, text, PathBuf::from("test.md"));
+            assert_eq!(
+                parsed.references.len(),
+                1,
+                "{text:?}: {:?}",
+                parsed.references
+            );
+            assert_eq!(parsed.references[0].reference_text, "target", "{text:?}");
+        }
+    }
+
+    #[test]
+    fn reference_boundaries_in_code_respect_opt_in() {
+        let text = "`[[inline]]`\n```md\n[[fenced]]\n```";
+        let mut settings = test_settings();
+        settings.references_in_codeblocks = true;
+        let parsed = MDFile::new(&settings, text, PathBuf::from("test.md"));
+        let references: Vec<_> = parsed
+            .references
+            .iter()
+            .map(|reference| reference.reference_text.as_str())
+            .collect();
+        assert_eq!(references, vec!["inline", "fenced"]);
     }
 
     #[test]


### PR DESCRIPTION
Fixes #269.

The reference regex can match an opening `[[` in one code span and a closing `]]` in another. The existing containment check keeps that match, so the issue's literal-bracket example gets an incorrect unresolved-reference diagnostic.

Exclude references whose opening or closing boundary is inside code, using exclusive range ends. Valid links directly beside inline code and links with code inside their labels remain available. The `references_in_codeblocks` option keeps its existing behavior.

Validation:

- Added three regression tests covering 15 cases, including the reported sentence, inline and fenced boundaries, adjacent code, wiki/Markdown code labels, and the opt-in setting. The reported case fails against the previous implementation.
- `cargo test --locked`: 80 passed.
- `cargo build --locked`, `cargo fmt --check`, and `cargo clippy --locked` pass. Clippy reports warnings in unchanged code.
- Actual Neovim 0.12.5 LSP checks: the false diagnostic is removed; an intentional missing-note diagnostic remains; definitions for three valid links and hover still return the same results.
- Both baseline and patched runs pass the repository's editor feature checks in fresh temporary `TestFiles` copies: real wiki completion and filtering, Ctrl+Y block completion with the generated target ID verified on disk after `:wall`, go-to-definition, hover with preview/backlinks, and hierarchical tag completion. All original fixtures remain unchanged. Supplemental terminal recordings cover both runs.

AI assistance: Codex implemented the change, ran the Rust checks and exercised the actual Neovim/LSP integration through automated editor input and assertions. Before-and-after terminal recordings demonstrate the issue and fix, with a supplemental pair covering the required editor features. This was tested in Neovim 0.12.5; other editors were not tested.

/claim #269
